### PR TITLE
MODBULKOPS-1 Use a sensible operationId, no spaces

### DIFF
--- a/src/main/resources/swagger.api/bulk-operations.yaml
+++ b/src/main/resources/swagger.api/bulk-operations.yaml
@@ -9,7 +9,7 @@ servers:
 paths:
   /to-be-changed:
     get:
-      operationId: example endpoint to generate api doc
+      operationId: getExample
       description: example endpoint to generate api doc
       responses:
         '200':


### PR DESCRIPTION
The api-doc tool was not expecting spaces in an identifier. Patched now, but takes time to roll out to Jenkins, so fixed here.

Also this is an initial PR so that branch-protection settings can be enabled:
https://dev.folio.org/guidelines/create-new-repo/#configuration-at-github
