### PR TITLE
MODBULKOPS-15: Upgrade dependencies; fix jackson and snakeyaml vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -32,9 +32,12 @@
     <argLine/>
     <bulk-operations.yaml.file>${project.basedir}/src/main/resources/swagger.api/bulk-operations.yaml</bulk-operations.yaml.file>
 
-    <folio-spring-base.version>5.0.1</folio-spring-base.version>
+    <folio-spring-base.version>5.0.2</folio-spring-base.version>
+    <jackson-bom.version>2.14.1</jackson-bom.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
-    <spring-kafka.version>2.9.2</spring-kafka.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
+    <spring-kafka.version>2.9.3</spring-kafka.version>
+    <postgresql.version>42.5.1</postgresql.version>
     <apache-commons-io.version>2.11.0</apache-commons-io.version>
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
     <lombok.version>1.18.24</lombok.version>
@@ -42,7 +45,7 @@
 
     <!-- Test dependencies versions -->
     <testcontainer.version>1.17.6</testcontainer.version>
-    <wiremock.version>2.27.2</wiremock.version>
+    <wiremock.version>2.35.0</wiremock.version>
     <awaitility.version>4.2.0</awaitility.version>
 
     <!-- Plugins versions -->
@@ -209,7 +212,7 @@
 
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock-jre8-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Upgrade all dependencies.

Upgrading postgresql from 42.3.6 to 42.5.1 fixes SQL Injection and Information Disclosure:
https://nvd.nist.gov/vuln/detail/CVE-2022-31197
https://nvd.nist.gov/vuln/detail/CVE-2022-41946

Note that postgresql 42.3 and 42.4 have reached their end of life and are no longer supported:
https://jdbc.postgresql.org/download/

Upgrading folio-spring-base from 5.0.1 to 5.0.2 indirectly upgrades commons-text from 1.9 to 1.10.0 fixing Arbitrary Code Execution:
https://nvd.nist.gov/vuln/detail/CVE-2022-42889

Upgrading jackson from 2.13.3 to 2.14.1 fixes Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrading snakeyaml from 1.30 (version managed by spring-boot-starter-web) to 1.33 fixes Denial of Service (DoS) and Stack-based Buffer Overflow:
https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749
https://nvd.nist.gov/vuln/detail/CVE-2022-38750
https://nvd.nist.gov/vuln/detail/CVE-2022-38751
https://nvd.nist.gov/vuln/detail/CVE-2022-38752
https://nvd.nist.gov/vuln/detail/CVE-2022-41854

Upgrading spring-boot-starter-web from 2.7.3 to 2.7.5 indirectly upgrades tomcat-embed-core from 9.0.65 to 9.0.68 fixing HTTP Request Smuggling:
https://nvd.nist.gov/vuln/detail/CVE-2022-42252