### PR TITLE
MODEXPW-375 pass folioExecutionContext to ExecutorService's threads

### DIFF
--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -16,6 +16,7 @@ import static org.folio.bulkops.domain.dto.OperationStatusType.NEW;
 import static org.folio.bulkops.domain.dto.OperationStatusType.RETRIEVING_RECORDS;
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
 import static org.folio.bulkops.util.Utils.resolveEntityClass;
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -457,10 +458,10 @@ public class BulkOperationService {
       operation.setCommittedNumOfErrors(0);
       if (DATA_MODIFICATION.equals(operation.getStatus()) || REVIEW_CHANGES.equals(operation.getStatus())) {
         if (MANUAL == approach) {
-          executor.execute(() -> apply(operation));
+          executor.execute(getRunnableWithCurrentFolioContext(() -> apply(operation)));
         } else {
           clear(operation);
-          executor.execute(() -> confirm(operation));
+          executor.execute(getRunnableWithCurrentFolioContext(() -> confirm(operation)));
         }
         return operation;
       } else {
@@ -468,7 +469,7 @@ public class BulkOperationService {
       }
     } else if (BulkOperationStep.COMMIT == step) {
       if (REVIEW_CHANGES.equals(operation.getStatus())) {
-        executor.execute(() -> commit(operation));
+        executor.execute(getRunnableWithCurrentFolioContext(() -> commit(operation)));
         return operation;
       } else {
         throw new BadRequestException(String.format(STEP_S_IS_NOT_APPLICABLE_FOR_BULK_OPERATION_STATUS, step, operation.getStatus()));


### PR DESCRIPTION
<!--
   If you have a relevant JIRA issue number, please put it in the issue title.
   Example: MODBULKOPS-1 - Setup mod-bulk-operations module
   TL;DR
     - https://www.youtube.com/watch?v=5aHmO_S8FQ4
     - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
     - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
 -->

## Purpose
Fixes https://issues.folio.org/browse/MODEXPW-375  for mod-bulk-operations module

## Approach
There were cases when incorrect headers were sent by feign client(for ex. headers related to another user). It was caused by the fact that folioExecutionContext wasn't passed to threads created by BulkOperationServices's ExecutorService. Since InheritableThreadLocal is used in folioExecutionContext, these child threads still were initialized with folioExecutionContext which was present upon their creation, but it was never cleaned up/updated. EnrichUrlAndHeadersClient takes headers from the thread local folioExecutionContext and adds them to feign request, so in such case it was using same cached values for all requests.

The fix is to pass folioExecutionContext to runnable task and clean it up in the end (use FolioExecutionScopeExecutionContextManager::getRunnableWithCurrentFolioContext)
 <!--
  How does this change fulfill the purpose? It's best to talk
  high-level strategy and avoid code-splaining the commit history.
  The goal is not only to explain what you did, but help other
  developers *work* with your solution in the future.
 -->

### TODOS and Open Questions
 <!-- OPTIONAL
 - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
 -->

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
