### PR TITLE
MODBULKOPS-57 - Empty "File with updated records" is included in the list of files for downloading when no records have been successfully changed

### DIFF
--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -358,7 +358,9 @@ public class BulkOperationService {
         execution.setProcessedRecords(processedNumOfRecords);
         operation.setProcessedNumOfRecords(committedNumOfRecords);
         operation.setEndTime(LocalDateTime.now());
-        operation.setLinkToCommittedRecordsCsvFile(resultCsvFileName);
+        if (committedNumOfRecords > 0) {
+          operation.setLinkToCommittedRecordsCsvFile(resultCsvFileName);
+        }
         operation.setLinkToCommittedRecordsJsonFile(resultJsonFileName);
         operation.setCommittedNumOfErrors((operation.getCommittedNumOfErrors() != null ? operation.getCommittedNumOfErrors() : 0) + committedNumOfErrors);
         operation.setCommittedNumOfRecords(committedNumOfRecords);

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -360,8 +360,8 @@ public class BulkOperationService {
         operation.setEndTime(LocalDateTime.now());
         if (committedNumOfRecords > 0) {
           operation.setLinkToCommittedRecordsCsvFile(resultCsvFileName);
+          operation.setLinkToCommittedRecordsJsonFile(resultJsonFileName);
         }
-        operation.setLinkToCommittedRecordsJsonFile(resultJsonFileName);
         operation.setCommittedNumOfErrors((operation.getCommittedNumOfErrors() != null ? operation.getCommittedNumOfErrors() : 0) + committedNumOfErrors);
         operation.setCommittedNumOfRecords(committedNumOfRecords);
       } catch (Exception e) {

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -9,6 +9,7 @@ import static org.folio.bulkops.domain.dto.OperationStatusType.DATA_MODIFICATION
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -641,6 +642,7 @@ class BulkOperationServiceTest extends BaseTest {
     Awaitility.await().untilAsserted(() -> verify(remoteFileSystemClient, times(2)).writer(pathCaptor.capture()));
     assertEquals(expectedPathToResultCsvFile, pathCaptor.getAllValues().get(0));
     assertEquals(expectedPathToResultFile, pathCaptor.getAllValues().get(1));
+    assertNull(operation.getLinkToCommittedRecordsCsvFile());
   }
 
   @Test


### PR DESCRIPTION
[MODBULKOPS-57](https://issues.folio.org/browse/MODBULKOPS-57) - Empty "File with updated records" is included in the list of files for downloading when no records have been successfully changed

## Purpose
Remove option to download the result file if no changes were made.

## Approach
Check number of committed records and set link to the result file only if more than 0.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
