### PR TITLE
MODBULKOPS-90 - Remove redundant data-export-worker call

### DIFF
--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -517,9 +517,6 @@ public class BulkOperationService {
             if (JobStatus.FAILED.equals(job.getStatus())) {
               errorMessage = "Data export job failed";
             } else {
-              if (QUERY != approach && JobStatus.SCHEDULED.equals(job.getStatus())) {
-                bulkEditClient.startJob(job.getId());
-              }
               operation.setStatus(RETRIEVING_RECORDS);
             }
           } else {


### PR DESCRIPTION
[MODBULKOPS-90](https://issues.folio.org/browse/MODBULKOPS-90) - Remove redundant data-export-worker call

## Purpose
As per [MODEXPW-386](https://issues.folio.org/browse/MODEXPW-386) jobs start automatically after identifiers uploading, there is no need to make separate job start call. Appropriate code block should be removed from BulkOperationService component.

## Approach
* Removed redundant logic
* Removed redundant unit test

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
