### PR TITLE
MODBULKOPS-66 - TD - BulkOps: UnifiedTable header should be reflected from csv models

### DIFF
--- a/src/main/java/org/folio/bulkops/util/UnifiedTableHeaderBuilder.java
+++ b/src/main/java/org/folio/bulkops/util/UnifiedTableHeaderBuilder.java
@@ -3,13 +3,19 @@ package org.folio.bulkops.util;
 import static org.folio.bulkops.domain.dto.DataType.STRING;
 
 import com.opencsv.bean.CsvCustomBindByName;
+import com.opencsv.bean.CsvCustomBindByPosition;
+import com.opencsv.bean.CsvRecurse;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.folio.bulkops.domain.bean.BulkOperationsEntity;
 import org.folio.bulkops.domain.dto.Cell;
 import org.folio.bulkops.domain.dto.UnifiedTable;
 
+import java.lang.reflect.Field;
 import java.util.List;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @UtilityClass
 public class UnifiedTableHeaderBuilder {
@@ -18,8 +24,18 @@ public class UnifiedTableHeaderBuilder {
   }
 
   public static List<Cell> getHeaders(Class<? extends BulkOperationsEntity> clazz) {
-    return FieldUtils.getFieldsListWithAnnotation(clazz, CsvCustomBindByName.class).stream()
-      .map(field -> new Cell().dataType(STRING).value(field.getAnnotation(CsvCustomBindByName.class).column()).visible(true))
-      .toList();
+    return Stream.concat(
+        FieldUtils.getFieldsListWithAnnotation(clazz, CsvRecurse.class).stream()
+          .map(Field::getType)
+          .map(aClass -> FieldUtils.getFieldsListWithAnnotation(aClass, CsvCustomBindByName.class))
+          .flatMap(List::stream),
+        FieldUtils.getFieldsListWithAnnotation(clazz, CsvCustomBindByName.class).stream())
+      .collect(Collectors.toMap(field -> field.getAnnotation(CsvCustomBindByPosition.class).position(),
+        field -> field.getAnnotation(CsvCustomBindByName.class).column(),
+        (key1, key2) -> key1,
+        TreeMap::new))
+      .values().stream()
+        .map(val -> new Cell().dataType(STRING).value(val).visible(true))
+        .toList();
   }
 }


### PR DESCRIPTION
[MODBULKOPS-66](https://issues.folio.org/browse/MODBULKOPS-66) - TD - BulkOps: UnifiedTable header should be reflected from csv models

## Purpose
At he present moment headers in the csv file and preview page comes from different sources. Right way to populate it from csv models (user, item, holding) extracting names from Csv-binding annotations.
1) Existing logic for generating headers from preview page should be deleted
2) Corresponding names should be extracted from csv models

## Approach
 * Improved header builder logic

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
