### PR TITLE
MODBULKOPS-52 - Name of downloaded file from "Logs" tab does not adhere to the naming standard

### DIFF
--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -139,7 +139,7 @@ public class BulkOperationService {
           .orElseThrow(() -> new NotFoundException("Bulk operation was not found by id=" + operationId));
 
         try {
-          var linkToThePreviewFile = remoteFileSystemClient.put(multipartFile.getInputStream(), operation.getId() + "/" + multipartFile.getOriginalFilename());
+          var linkToThePreviewFile = remoteFileSystemClient.put(multipartFile.getInputStream(), String.format(PREVIEW_CSV_PATH_TEMPLATE, operation.getId(), LocalDate.now(), FilenameUtils.getBaseName(operation.getLinkToTriggeringCsvFile())));
           operation.setLinkToModifiedRecordsCsvFile(linkToThePreviewFile);
 
           var numOfLines = remoteFileSystemClient.getNumOfLines(linkToThePreviewFile) - 1;

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -177,12 +177,13 @@ class BulkOperationServiceTest extends BaseTest {
       .thenReturn(BulkOperation.builder().id(operationId).build());
 
     when(bulkOperationRepository.findById(operationId))
-      .thenReturn(Optional.of(BulkOperation.builder().id(operationId).status(DATA_MODIFICATION).build()));
+      .thenReturn(Optional.of(BulkOperation.builder().id(operationId).linkToTriggeringCsvFile("path/barcodes.csv").status(DATA_MODIFICATION).build()));
 
-    when(remoteFileSystemClient.put(any(InputStream.class), eq(operationId + "/barcodes.csv")))
-      .thenReturn("modified.csv");
+    var linkToPreviewFile = operationId + "/" + LocalDate.now() + "-Updates-Preview-barcodes.csv";
+    when(remoteFileSystemClient.put(any(InputStream.class), eq(linkToPreviewFile)))
+      .thenReturn(linkToPreviewFile);
 
-    when(remoteFileSystemClient.getNumOfLines("modified.csv"))
+    when(remoteFileSystemClient.getNumOfLines(linkToPreviewFile))
       .thenReturn(3);
 
     bulkOperationService.uploadCsvFile(USER, IdentifierType.BARCODE, true, operationId, UUID.randomUUID(), file);


### PR DESCRIPTION
[MODBULKOPS-52](https://issues.folio.org/browse/MODBULKOPS-52) - Name of downloaded file from "Logs" tab does not adhere to the naming standard

## Approach
Improvements for CSV approach

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
