### PR TITLE
MODBULKOPS-136 - Reduce impact of "No changes required" on "Are you sure?" form performance

### DIFF
--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -348,9 +348,11 @@ public class BulkOperationService {
 
           try {
             var result = updateEntityIfNeeded(original, modified, operation, entityClass);
-            var hasNextRecord = hasNextRecord(originalFileIterator, modifiedFileIterator);
-            writerForResultJsonFile.write(objectMapper.writeValueAsString(result) + (hasNextRecord ? LF : EMPTY));
-            sbc.write(result);
+            if (result != original) {
+              var hasNextRecord = hasNextRecord(originalFileIterator, modifiedFileIterator);
+              writerForResultJsonFile.write(objectMapper.writeValueAsString(result) + (hasNextRecord ? LF : EMPTY));
+              sbc.write(result);
+            }
             execution = execution
               .withStatus(originalFileIterator.hasNext() ? StatusType.ACTIVE : StatusType.COMPLETED)
               .withEndTime(originalFileIterator.hasNext() ? null : LocalDateTime.now());

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Awaitility;
 import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.client.BulkEditClient;
@@ -715,10 +716,13 @@ class BulkOperationServiceTest extends BaseTest {
 
     var expectedPathToResultFile = bulkOperationId + "/json/" + LocalDate.now() + "-Changed-Records-identifiers.json";
     var expectedPathToResultCsvFile = bulkOperationId + "/" + LocalDate.now() + "-Changed-Records-identifiers.csv";
+
+    var jsonWriter = new StringWriter();
     when(remoteFileSystemClient.writer(expectedPathToResultFile))
-      .thenReturn(new StringWriter());
+      .thenReturn(jsonWriter);
+    var csvWriter = new StringWriter();
     when(remoteFileSystemClient.writer(expectedPathToResultCsvFile))
-      .thenReturn(new StringWriter());
+      .thenReturn(csvWriter);
 
     when(executionContentRepository.save(any(BulkOperationExecutionContent.class)))
       .thenReturn(BulkOperationExecutionContent.builder().build());
@@ -734,6 +738,8 @@ class BulkOperationServiceTest extends BaseTest {
     assertEquals(expectedPathToResultCsvFile, pathCaptor.getAllValues().get(0));
     assertEquals(expectedPathToResultFile, pathCaptor.getAllValues().get(1));
     assertNull(operation.getLinkToCommittedRecordsCsvFile());
+    assertEquals(StringUtils.EMPTY, jsonWriter.toString());
+    assertEquals(StringUtils.EMPTY, csvWriter.toString());
   }
 
   @Test


### PR DESCRIPTION
[MODBULKOPS-136](https://issues.folio.org/browse/MODBULKOPS-136) - Reduce impact of "No changes required" on "Are you sure?" form performance

## Purpose
The main reason for slowing down the "Are you sure?" form is to check the equality of the updated entities (users, items, holdings - In-app approach). This logic should be moved to the commit phase (UpdateProcessor) as it is logically consistent with the commit phase and will also prevent the form from slowing down.

## Approach
* Improved logic
* Updated tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
