### PR TITLE
MODBULKOPS-112 - File deletion API for Bulk Operations

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -173,6 +173,12 @@
           "pathPattern": "/bulk-operations/{operationId}/files/{fileName}",
           "permissionsRequired": ["bulk-operations.files.item.delete"],
           "modulePermissions": [ ]
+        },
+        {
+          "methods": [ "DELETE" ],
+          "pathPattern": "/bulk-operations/{operationId}/cancel",
+          "permissionsRequired": ["bulk-operations.item.cancel.post"],
+          "modulePermissions": [ ]
         }
       ]
     },
@@ -276,6 +282,11 @@
       "description" : "Delete file by operation id and file name"
     },
     {
+      "permissionName": "bulk-operations.item.cancel.post",
+      "displayName" : "cancel operation by id",
+      "description" : "Cancel operation by id"
+    },
+    {
       "permissionName" : "bulk-operations.all",
       "displayName" : "bulk-operations all",
       "description" : "All permissions for bulk-operations module",
@@ -291,7 +302,8 @@
         "bulk-operations.collection.get",
         "bulk-operations.download.item.get",
         "bulk-operations.list-users.collection.get",
-        "bulk-operations.files.item.delete"
+        "bulk-operations.files.item.delete",
+        "bulk-operations.item.cancel.post"
       ]
     }
   ],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -175,7 +175,7 @@
           "modulePermissions": [ ]
         },
         {
-          "methods": [ "DELETE" ],
+          "methods": [ "POST" ],
           "pathPattern": "/bulk-operations/{operationId}/cancel",
           "permissionsRequired": ["bulk-operations.item.cancel.post"],
           "modulePermissions": [ ]

--- a/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
+++ b/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
@@ -157,14 +157,14 @@ public class BulkOperationController implements BulkOperationsApi {
 
   @Override
   public ResponseEntity<Void> deleteFileByNameAndOperationId(UUID operationId, String fileName) {
-    log.debug("Deleting file {} for bulk operation id={}", fileName, operationId);
+    log.info("Deleting file {} for bulk operation id={}", fileName, operationId);
     logFilesService.deleteFileByOperationIdAndName(operationId, fileName);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
   @Override
   public ResponseEntity<Void> cancelOperationById(UUID operationId) {
-    log.debug("Cancelling bulk operation id={}", operationId);
+    log.info("Cancelling bulk operation id={}", operationId);
     bulkOperationService.cancelOperationById(operationId);
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
+++ b/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
@@ -157,14 +157,14 @@ public class BulkOperationController implements BulkOperationsApi {
 
   @Override
   public ResponseEntity<Void> deleteFileByNameAndOperationId(UUID operationId, String fileName) {
-    log.info("Deleting file {} for bulk operation id={}", fileName, operationId);
+    log.debug("Deleting file {} for bulk operation id={}", fileName, operationId);
     logFilesService.deleteFileByOperationIdAndName(operationId, fileName);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
   @Override
   public ResponseEntity<Void> cancelOperationById(UUID operationId) {
-    log.info("Cancelling bulk operation id={}", operationId);
+    log.debug("Cancelling bulk operation id={}", operationId);
     bulkOperationService.cancelOperationById(operationId);
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
+++ b/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
@@ -161,4 +161,11 @@ public class BulkOperationController implements BulkOperationsApi {
     logFilesService.deleteFileByOperationIdAndName(operationId, fileName);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
+
+  @Override
+  public ResponseEntity<Void> cancelOperationById(UUID operationId) {
+    log.info("Cancelling bulk operation id={}", operationId);
+    bulkOperationService.cancelOperationById(operationId);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
 }

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -656,7 +656,7 @@ public class BulkOperationService {
     var operation = getBulkOperationOrThrow(operationId);
     if (Set.of(NEW, RETRIEVING_RECORDS, SAVING_RECORDS_LOCALLY).contains(operation.getStatus())) {
       logFilesService.removeTriggeringAndMatchedRecordsFiles(operation);
-    } else if (DATA_MODIFICATION.equals(operation.getStatus()) && MANUAL.equals(operation.getApproach())) {
+    } else if (Set.of(DATA_MODIFICATION, REVIEW_CHANGES).contains(operation.getStatus()) && MANUAL.equals(operation.getApproach())) {
       logFilesService.removeModifiedFiles(operation);
     } else {
       throw new IllegalOperationStateException(String.format("Operation with status %s cannot be cancelled", operation.getStatus()));

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -483,7 +483,7 @@ public class BulkOperationService {
         if (MANUAL == approach) {
           executor.execute(getRunnableWithCurrentFolioContext(() -> apply(operation)));
         } else {
-          clear(operation);
+          logFilesService.removeModifiedFiles(operation);
           executor.execute(getRunnableWithCurrentFolioContext(() -> confirm(operation)));
         }
         return operation;
@@ -499,17 +499,6 @@ public class BulkOperationService {
       }
     } else {
       throw new IllegalOperationStateException("Bulk operation cannot be started, reason: invalid state: " + operation.getStatus());
-    }
-  }
-
-  private void clear(BulkOperation operation) {
-    if (isNotEmpty(operation.getLinkToModifiedRecordsJsonFile())) {
-      remoteFileSystemClient.remove(operation.getLinkToModifiedRecordsJsonFile());
-      operation.setLinkToModifiedRecordsJsonFile(null);
-    }
-    if (isNotEmpty(operation.getLinkToModifiedRecordsCsvFile())) {
-      remoteFileSystemClient.remove(operation.getLinkToModifiedRecordsCsvFile());
-      operation.setLinkToModifiedRecordsCsvFile(null);
     }
   }
 

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -19,6 +19,7 @@ import static org.folio.bulkops.domain.dto.OperationStatusType.FAILED;
 import static org.folio.bulkops.domain.dto.OperationStatusType.NEW;
 import static org.folio.bulkops.domain.dto.OperationStatusType.RETRIEVING_RECORDS;
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
+import static org.folio.bulkops.domain.dto.OperationStatusType.SAVING_RECORDS_LOCALLY;
 import static org.folio.bulkops.util.Constants.FIELD_ERROR_MESSAGE_PATTERN;
 import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
 import static org.folio.bulkops.util.Utils.resolveEntityClass;
@@ -31,11 +32,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.bulkops.client.BulkEditClient;
@@ -118,6 +119,7 @@ public class BulkOperationService {
   private final DataProcessorFactory dataProcessorFactory;
   private final UpdateProcessorFactory updateProcessorFactory;
   private final ErrorService errorService;
+  private final LogFilesService logFilesService;
 
   private static final int OPERATION_UPDATING_STEP = 100;
   private static final String PREVIEW_JSON_PATH_TEMPLATE = "%s/json/%s-Updates-Preview-%s.json";
@@ -648,5 +650,17 @@ public class BulkOperationService {
 
   private boolean hasNextRecord(MappingIterator<? extends BulkOperationsEntity> originalFileIterator, MappingIterator<? extends BulkOperationsEntity> modifiedFileIterator) {
     return originalFileIterator.hasNext() && modifiedFileIterator.hasNext();
+  }
+
+  public void cancelOperationById(UUID operationId) {
+    var operation = getBulkOperationOrThrow(operationId);
+    if (Set.of(NEW, RETRIEVING_RECORDS, SAVING_RECORDS_LOCALLY).contains(operation.getStatus())) {
+      logFilesService.removeTriggeringAndMatchedRecordsFiles(operation);
+    } else if (DATA_MODIFICATION.equals(operation.getStatus()) && MANUAL.equals(operation.getApproach())) {
+      logFilesService.removeModifiedFiles(operation);
+    } else {
+      throw new IllegalOperationStateException(String.format("Operation with status %s cannot be cancelled", operation.getStatus()));
+    }
+    bulkOperationRepository.save(operation);
   }
 }

--- a/src/main/java/org/folio/bulkops/service/LogFilesService.java
+++ b/src/main/java/org/folio/bulkops/service/LogFilesService.java
@@ -72,6 +72,7 @@ public class LogFilesService {
   }
 
   public void removeTriggeringAndMatchedRecordsFiles(BulkOperation bulkOperation) {
+    log.info("Attempting to delete triggering and matched records files...");
     if (isNotEmpty(bulkOperation.getLinkToTriggeringCsvFile())) {
       remoteFileSystemClient.remove(bulkOperation.getLinkToTriggeringCsvFile());
       bulkOperation.setLinkToTriggeringCsvFile(null);
@@ -91,6 +92,7 @@ public class LogFilesService {
   }
 
   public void removeModifiedFiles(BulkOperation bulkOperation) {
+    log.info("Attempting to delete modified records files...");
     if (isNotEmpty(bulkOperation.getLinkToModifiedRecordsJsonFile())) {
       remoteFileSystemClient.remove(bulkOperation.getLinkToModifiedRecordsJsonFile());
       bulkOperation.setLinkToModifiedRecordsJsonFile(null);

--- a/src/main/java/org/folio/bulkops/service/LogFilesService.java
+++ b/src/main/java/org/folio/bulkops/service/LogFilesService.java
@@ -43,25 +43,11 @@ public class LogFilesService {
   }
 
   private void removeFiles(BulkOperation bulkOperation) {
-    if (isNotEmpty(bulkOperation.getLinkToModifiedRecordsJsonFile())) {
-      remoteFileSystemClient.remove(bulkOperation.getLinkToModifiedRecordsJsonFile());
-      bulkOperation.setLinkToModifiedRecordsJsonFile(null);
-    }
-    if (isNotEmpty(bulkOperation.getLinkToTriggeringCsvFile())) {
-      remoteFileSystemClient.remove(bulkOperation.getLinkToTriggeringCsvFile());
-      bulkOperation.setLinkToTriggeringCsvFile(null);
-    }
-    if (isNotEmpty(bulkOperation.getLinkToMatchedRecordsErrorsCsvFile())) {
-      remoteFileSystemClient.remove(bulkOperation.getLinkToMatchedRecordsErrorsCsvFile());
-      bulkOperation.setLinkToMatchedRecordsErrorsCsvFile(null);
-    }
+    removeTriggeringAndMatchedRecordsFiles(bulkOperation);
+    removeModifiedFiles(bulkOperation);
     if (isNotEmpty(bulkOperation.getLinkToCommittedRecordsJsonFile())) {
       remoteFileSystemClient.remove(bulkOperation.getLinkToCommittedRecordsJsonFile());
       bulkOperation.setLinkToCommittedRecordsJsonFile(null);
-    }
-    if (isNotEmpty(bulkOperation.getLinkToMatchedRecordsCsvFile())) {
-      remoteFileSystemClient.remove(bulkOperation.getLinkToMatchedRecordsCsvFile());
-      bulkOperation.setLinkToMatchedRecordsCsvFile(null);
     }
     if (isNotEmpty(bulkOperation.getLinkToCommittedRecordsErrorsCsvFile())) {
       remoteFileSystemClient.remove(bulkOperation.getLinkToCommittedRecordsErrorsCsvFile());
@@ -70,14 +56,6 @@ public class LogFilesService {
     if (isNotEmpty(bulkOperation.getLinkToCommittedRecordsCsvFile())) {
       remoteFileSystemClient.remove(bulkOperation.getLinkToCommittedRecordsCsvFile());
       bulkOperation.setLinkToCommittedRecordsCsvFile(null);
-    }
-    if (isNotEmpty(bulkOperation.getLinkToMatchedRecordsJsonFile())) {
-      remoteFileSystemClient.remove(bulkOperation.getLinkToMatchedRecordsJsonFile());
-      bulkOperation.setLinkToMatchedRecordsJsonFile(null);
-    }
-    if (isNotEmpty(bulkOperation.getLinkToModifiedRecordsCsvFile())) {
-      remoteFileSystemClient.remove(bulkOperation.getLinkToModifiedRecordsCsvFile());
-      bulkOperation.setLinkToModifiedRecordsCsvFile(null);
     }
     if (isNotEmpty(bulkOperation.getLinkToPreviewRecordsJsonFile())) {
       remoteFileSystemClient.remove(bulkOperation.getLinkToPreviewRecordsJsonFile());
@@ -91,5 +69,35 @@ public class LogFilesService {
     var jsonPath = format(JSON_PATH_TEMPLATE, operationId, baseName);
     remoteFileSystemClient.remove(csvPath, jsonPath);
     log.info("Deleted: {}, {}", csvPath, jsonPath);
+  }
+
+  public void removeTriggeringAndMatchedRecordsFiles(BulkOperation bulkOperation) {
+    if (isNotEmpty(bulkOperation.getLinkToTriggeringCsvFile())) {
+      remoteFileSystemClient.remove(bulkOperation.getLinkToTriggeringCsvFile());
+      bulkOperation.setLinkToTriggeringCsvFile(null);
+    }
+    if (isNotEmpty(bulkOperation.getLinkToMatchedRecordsCsvFile())) {
+      remoteFileSystemClient.remove(bulkOperation.getLinkToMatchedRecordsCsvFile());
+      bulkOperation.setLinkToMatchedRecordsCsvFile(null);
+    }
+    if (isNotEmpty(bulkOperation.getLinkToMatchedRecordsJsonFile())) {
+      remoteFileSystemClient.remove(bulkOperation.getLinkToMatchedRecordsJsonFile());
+      bulkOperation.setLinkToMatchedRecordsJsonFile(null);
+    }
+    if (isNotEmpty(bulkOperation.getLinkToMatchedRecordsErrorsCsvFile())) {
+      remoteFileSystemClient.remove(bulkOperation.getLinkToMatchedRecordsErrorsCsvFile());
+      bulkOperation.setLinkToMatchedRecordsErrorsCsvFile(null);
+    }
+  }
+
+  public void removeModifiedFiles(BulkOperation bulkOperation) {
+    if (isNotEmpty(bulkOperation.getLinkToModifiedRecordsJsonFile())) {
+      remoteFileSystemClient.remove(bulkOperation.getLinkToModifiedRecordsJsonFile());
+      bulkOperation.setLinkToModifiedRecordsJsonFile(null);
+    }
+    if (isNotEmpty(bulkOperation.getLinkToModifiedRecordsCsvFile())) {
+      remoteFileSystemClient.remove(bulkOperation.getLinkToModifiedRecordsCsvFile());
+      bulkOperation.setLinkToModifiedRecordsCsvFile(null);
+    }
   }
 }

--- a/src/main/resources/swagger.api/bulk-operations.yaml
+++ b/src/main/resources/swagger.api/bulk-operations.yaml
@@ -446,6 +446,39 @@ paths:
               schema:
                 type: string
                 example: Internal server error
+  /bulk-operations/{operationId}/cancel:
+    post:
+      description: Cancel bulk operation by id
+      operationId: cancelOperationById
+      parameters:
+        - in: path
+          name: operationId
+          required: true
+          schema:
+            $ref: "#/components/schemas/UUID"
+          description: UUID of the Bulk Operation
+      responses:
+        '200':
+          description: Operation cancelled
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errors"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errors"
+        '500':
+          description: Internal server errors, e.g. due to misconfiguration
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
 components:
   schemas:
     bulkOperationCollection:

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -76,6 +76,7 @@ import org.folio.bulkops.domain.entity.BulkOperationDataProcessing;
 import org.folio.bulkops.domain.entity.BulkOperationExecution;
 import org.folio.bulkops.domain.entity.BulkOperationExecutionContent;
 import org.folio.bulkops.exception.BadRequestException;
+import org.folio.bulkops.exception.IllegalOperationStateException;
 import org.folio.bulkops.exception.NotFoundException;
 import org.folio.bulkops.repository.BulkOperationDataProcessingRepository;
 import org.folio.bulkops.repository.BulkOperationExecutionContentRepository;
@@ -986,6 +987,68 @@ class BulkOperationServiceTest extends BaseTest {
 
     verify(dataProcessingRepository).deleteById(any(UUID.class));
     verify(bulkOperationRepository).save(any(BulkOperation.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = OperationStatusType.class, names = {"NEW", "RETRIEVING_RECORDS", "SAVING_RECORDS_LOCALLY"})
+  void shouldRemoveTriggeringAndMatchedRecordsFilesOnCancel(OperationStatusType type) {
+    var operationId = UUID.randomUUID();
+    var linkToTriggeringCsv = "identifiers.csv";
+    var linkToMatchedCsv = "matched.csv";
+    var linkToMatchedJson = "matched.json";
+    var linkToMatchedErrorsCsv = "matched-errors.csv";
+
+    when(bulkOperationRepository.findById(operationId))
+      .thenReturn(Optional.of(BulkOperation.builder()
+        .id(operationId)
+        .linkToTriggeringCsvFile(linkToTriggeringCsv)
+        .linkToMatchedRecordsCsvFile(linkToMatchedCsv)
+        .linkToMatchedRecordsJsonFile(linkToMatchedJson)
+        .linkToMatchedRecordsErrorsCsvFile(linkToMatchedErrorsCsv)
+        .status(type)
+        .build()));
+
+    bulkOperationService.cancelOperationById(operationId);
+
+    verify(remoteFileSystemClient).remove(linkToTriggeringCsv);
+    verify(remoteFileSystemClient).remove(linkToMatchedCsv);
+    verify(remoteFileSystemClient).remove(linkToMatchedJson);
+    verify(remoteFileSystemClient).remove(linkToMatchedErrorsCsv);
+  }
+
+  @Test
+  void shouldRemoveModifiedRecordsFilesOnCancel() {
+    var operationId = UUID.randomUUID();
+    var linkToModifiedCsv = "modified.csv";
+    var linkToModifiedJson = "modified.json";
+
+    when(bulkOperationRepository.findById(operationId))
+      .thenReturn(Optional.of(BulkOperation.builder()
+        .id(operationId)
+        .status(DATA_MODIFICATION)
+        .approach(ApproachType.MANUAL)
+        .linkToModifiedRecordsCsvFile(linkToModifiedCsv)
+        .linkToModifiedRecordsJsonFile(linkToModifiedJson)
+        .build()));
+
+    bulkOperationService.cancelOperationById(operationId);
+
+    verify(remoteFileSystemClient).remove(linkToModifiedCsv);
+    verify(remoteFileSystemClient).remove(linkToModifiedJson);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = OperationStatusType.class, names = {"NEW", "RETRIEVING_RECORDS", "SAVING_RECORDS_LOCALLY", "DATA_MODIFICATION"}, mode = EnumSource.Mode.EXCLUDE)
+  void shouldThrowExceptionOnInvalidStatusForCancel(OperationStatusType type) {
+    var operationId = UUID.randomUUID();
+
+    when(bulkOperationRepository.findById(operationId))
+      .thenReturn(Optional.of(BulkOperation.builder()
+        .id(operationId)
+        .status(type)
+        .build()));
+
+    assertThrows(IllegalOperationStateException.class, () -> bulkOperationService.cancelOperationById(operationId));
   }
 
   private BulkOperation buildBulkOperation(String fileName, EntityType entityType, BulkOperationStep step) {

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -1016,8 +1016,9 @@ class BulkOperationServiceTest extends BaseTest {
     verify(remoteFileSystemClient).remove(linkToMatchedErrorsCsv);
   }
 
-  @Test
-  void shouldRemoveModifiedRecordsFilesOnCancel() {
+  @ParameterizedTest
+  @EnumSource(value = OperationStatusType.class, names = {"DATA_MODIFICATION", "REVIEW_CHANGES"})
+  void shouldRemoveModifiedRecordsFilesOnCancel(OperationStatusType type) {
     var operationId = UUID.randomUUID();
     var linkToModifiedCsv = "modified.csv";
     var linkToModifiedJson = "modified.json";
@@ -1025,7 +1026,7 @@ class BulkOperationServiceTest extends BaseTest {
     when(bulkOperationRepository.findById(operationId))
       .thenReturn(Optional.of(BulkOperation.builder()
         .id(operationId)
-        .status(DATA_MODIFICATION)
+        .status(type)
         .approach(ApproachType.MANUAL)
         .linkToModifiedRecordsCsvFile(linkToModifiedCsv)
         .linkToModifiedRecordsJsonFile(linkToModifiedJson)
@@ -1038,7 +1039,7 @@ class BulkOperationServiceTest extends BaseTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = OperationStatusType.class, names = {"NEW", "RETRIEVING_RECORDS", "SAVING_RECORDS_LOCALLY", "DATA_MODIFICATION"}, mode = EnumSource.Mode.EXCLUDE)
+  @EnumSource(value = OperationStatusType.class, names = {"NEW", "RETRIEVING_RECORDS", "SAVING_RECORDS_LOCALLY", "DATA_MODIFICATION", "REVIEW_CHANGES"}, mode = EnumSource.Mode.EXCLUDE)
   void shouldThrowExceptionOnInvalidStatusForCancel(OperationStatusType type) {
     var operationId = UUID.randomUUID();
 


### PR DESCRIPTION
[MODBULKOPS-112](https://issues.folio.org/browse/MODBULKOPS-112) - File deletion API for Bulk Operations

## Purpose
Endpoint to delete file by name and bulk operation id should be implemented.

## Approach
* Added endpoint
* Added unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
