### PR TITLE
MODBULKOPS-146 Allow Tenant Collection Topics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 
     <folio-spring-base.version>7.0.0</folio-spring-base.version>
     <folio-spring-cql.version>7.0.0</folio-spring-cql.version>
+    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <apache-commons-io.version>2.11.0</apache-commons-io.version>
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
@@ -65,6 +66,11 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
       <version>${folio-spring-base.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-service-tools-spring-dev</artifactId>
+      <version>${folio-service-tools.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/bulkops/configs/kafka/KafkaService.java
+++ b/src/main/java/org/folio/bulkops/configs/kafka/KafkaService.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.tools.kafka.KafkaUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -97,7 +98,7 @@ public class KafkaService {
    * @return topic name as {@link String} object
    */
   private String getTenantTopicName(String topicName, String tenantId) {
-    return String.format("%s.%s.%s", environment, tenantId, topicName);
+    return KafkaUtils.getTenantTopicName(topicName, environment, tenantId);
   }
 
   public void send(Topic topic, String key, Object data) {


### PR DESCRIPTION
## Purpose
Allow tenant collection topics to be configurable. Tenant collection topics means a module will use a single topic for many tenants for the same event type.

## Approach
Pulled in the folio-service-tools library and used a utility to generate the topic name