### PR TITLE
MODBULKOPS-126 - Apply to item records when item suppression status differs from holding record

### DIFF
--- a/src/main/java/org/folio/bulkops/domain/bean/HoldingsRecord.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/HoldingsRecord.java
@@ -1,5 +1,8 @@
 package org.folio.bulkops.domain.bean;
 
+import static java.lang.Boolean.FALSE;
+import static java.util.Objects.isNull;
+
 import java.util.List;
 
 import org.folio.bulkops.domain.converter.BooleanConverter;
@@ -279,5 +282,9 @@ public class HoldingsRecord implements BulkOperationsEntity {
     case ITEM_BARCODE -> itemBarcode;
     default -> id;
     };
+  }
+
+  public Boolean getDiscoverySuppress() {
+    return isNull(discoverySuppress) ? FALSE : discoverySuppress;
   }
 }

--- a/src/main/java/org/folio/bulkops/domain/bean/Item.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/Item.java
@@ -1,5 +1,6 @@
 package org.folio.bulkops.domain.bean;
 
+import static java.lang.Boolean.FALSE;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -359,5 +360,9 @@ public class Item implements BulkOperationsEntity {
     case ACCESSION_NUMBER -> accessionNumber;
     default -> id;
     };
+  }
+
+  public Boolean getDiscoverySuppress() {
+    return isNull(discoverySuppress) ? FALSE : discoverySuppress;
   }
 }

--- a/src/main/java/org/folio/bulkops/processor/HoldingsDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/HoldingsDataProcessor.java
@@ -1,6 +1,9 @@
 package org.folio.bulkops.processor;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.folio.bulkops.domain.dto.UpdateActionType.CLEAR_FIELD;
 import static org.folio.bulkops.domain.dto.UpdateActionType.REPLACE_WITH;
@@ -69,6 +72,14 @@ public class HoldingsDataProcessor extends AbstractDataProcessor<HoldingsRecord>
       }
       if (PERMANENT_LOCATION == option && CLEAR_FIELD == action.getType()) {
         throw new RuleValidationException("Permanent location cannot be cleared");
+      }
+      if (SUPPRESS_FROM_DISCOVERY.equals(option)) {
+        if (SET_TO_TRUE_INCLUDING_ITEMS.equals(action.getType()) && TRUE.equals(entity.getDiscoverySuppress())) {
+          throw new RuleValidationException("No change in value for holdings record required, associated unsuppressed item(s) have been updated.");
+        } else if (SET_TO_FALSE_INCLUDING_ITEMS.equals(action.getType()) &&
+          (isNull(entity.getDiscoverySuppress()) || FALSE.equals(entity.getDiscoverySuppress()))) {
+          throw new RuleValidationException("No change in value for holdings record required, associated suppressed item(s) have been updated.");
+        }
       }
     };
   }

--- a/src/main/java/org/folio/bulkops/processor/HoldingsUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/HoldingsUpdateProcessor.java
@@ -17,7 +17,6 @@ public class HoldingsUpdateProcessor implements UpdateProcessor<HoldingsRecord> 
 
   @Override
   public void updateRecord(HoldingsRecord holdingsRecord, String identifier, UUID operationId) {
-    var ruleCollection = ruleService.getRules(operationId);
     holdingsClient.updateHoldingsRecord(
       holdingsRecord.withInstanceHrid(null).withItemBarcode(null).withInstanceTitle(null),
       holdingsRecord.getId()

--- a/src/main/java/org/folio/bulkops/processor/HoldingsUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/HoldingsUpdateProcessor.java
@@ -1,11 +1,7 @@
 package org.folio.bulkops.processor;
 
 import org.folio.bulkops.client.HoldingsClient;
-import org.folio.bulkops.client.ItemClient;
 import org.folio.bulkops.domain.bean.HoldingsRecord;
-import org.folio.bulkops.domain.dto.BulkOperationRuleCollection;
-import org.folio.bulkops.domain.dto.UpdateActionType;
-import org.folio.bulkops.service.ErrorService;
 import org.folio.bulkops.service.RuleService;
 import org.springframework.stereotype.Component;
 
@@ -13,18 +9,11 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
-import static org.folio.bulkops.domain.dto.UpdateOptionType.SUPPRESS_FROM_DISCOVERY;
-
 @Component
 @RequiredArgsConstructor
 public class HoldingsUpdateProcessor implements UpdateProcessor<HoldingsRecord> {
-
-  private static final String GET_ITEMS_BY_HOLDING_ID_QUERY = "holdingsRecordId=%s";
-
   private final HoldingsClient holdingsClient;
-  private final ItemClient itemClient;
   private final RuleService ruleService;
-  private final ErrorService errorService;
 
   @Override
   public void updateRecord(HoldingsRecord holdingsRecord, String identifier, UUID operationId) {
@@ -33,30 +22,6 @@ public class HoldingsUpdateProcessor implements UpdateProcessor<HoldingsRecord> 
       holdingsRecord.withInstanceHrid(null).withItemBarcode(null).withInstanceTitle(null),
       holdingsRecord.getId()
     );
-    if (isNeedToUpdateItemsDiscoverySupressValue(ruleCollection)) {
-      var items = itemClient.getByQuery(String.format(GET_ITEMS_BY_HOLDING_ID_QUERY, holdingsRecord.getId()))
-        .getItems();
-      items.forEach(item -> {
-        if (item.getDiscoverySuppress() == null || !item.getDiscoverySuppress().equals(holdingsRecord.getDiscoverySuppress())) {
-          item.setDiscoverySuppress(holdingsRecord.getDiscoverySuppress());
-          try {
-            itemClient.updateItem(item, item.getId());
-          } catch (Exception e) {
-            errorService.saveError(operationId, identifier, e.getMessage());
-          }
-        }
-      });
-    }
-  }
-
-  private boolean isNeedToUpdateItemsDiscoverySupressValue(BulkOperationRuleCollection ruleCollection) {
-    return ruleCollection.getBulkOperationRules().stream().anyMatch(rule -> {
-      var ruleDetails = rule.getRuleDetails();
-      var option = ruleDetails.getOption();
-      if (option != SUPPRESS_FROM_DISCOVERY) return false;
-      return ruleDetails.getActions().stream().anyMatch(action -> action.getType() == UpdateActionType.SET_TO_TRUE_INCLUDING_ITEMS ||
-        action.getType() == UpdateActionType.SET_TO_FALSE_INCLUDING_ITEMS);
-    });
   }
 
   @Override

--- a/src/test/java/org/folio/bulkops/processor/UpdateProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/UpdateProcessorTest.java
@@ -1,33 +1,18 @@
 package org.folio.bulkops.processor;
 
-import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_FALSE;
-import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_FALSE_INCLUDING_ITEMS;
-import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_TRUE;
-import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_TRUE_INCLUDING_ITEMS;
-import static org.folio.bulkops.domain.dto.UpdateOptionType.SUPPRESS_FROM_DISCOVERY;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.client.ItemClient;
 import org.folio.bulkops.domain.bean.HoldingsRecord;
 import org.folio.bulkops.domain.bean.Item;
-import org.folio.bulkops.domain.bean.ItemCollection;
 import org.folio.bulkops.domain.bean.ItemLocation;
 import org.folio.bulkops.domain.bean.User;
-import org.folio.bulkops.domain.dto.Action;
-import org.folio.bulkops.domain.dto.BulkOperationRule;
 import org.folio.bulkops.domain.dto.BulkOperationRuleCollection;
-import org.folio.bulkops.domain.dto.BulkOperationRuleRuleDetails;
 import org.folio.bulkops.service.ErrorService;
 import org.folio.bulkops.service.RuleService;
 import org.junit.jupiter.api.Test;
@@ -61,175 +46,6 @@ class UpdateProcessorTest extends BaseTest {
     holdingsUpdateProcessor.updateRecord(holdingsRecord,"identifier", UUID.randomUUID());
 
     verify(holdingsClient).updateHoldingsRecord(holdingsRecord, holdingsRecord.getId());
-  }
-
-  @Test
-  void shouldUpdateHoldingsAndItemsIfErrorUpdatingItemWhenIncludingItemsAction() {
-    var holdingsRecord = new HoldingsRecord()
-      .withId(UUID.randomUUID().toString())
-      .withInstanceId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(true)
-      .withPermanentLocation(new ItemLocation().withId(UUID.randomUUID().toString()));
-    var item = new Item()
-      .withId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(false);
-    var item2 = new Item()
-      .withId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(false);
-    var itemsCollection = new ItemCollection().withItems(List.of(item, item2));
-
-    var ruleDetails = new BulkOperationRuleRuleDetails();
-    ruleDetails.setOption(SUPPRESS_FROM_DISCOVERY);
-    var action = new Action();
-    action.setType(SET_TO_TRUE_INCLUDING_ITEMS);
-    ruleDetails.setActions(List.of(action));
-    var rule = new BulkOperationRule();
-    rule.setRuleDetails(ruleDetails);
-    var bulkOperationRuleCollection = new BulkOperationRuleCollection();
-    bulkOperationRuleCollection.setBulkOperationRules(List.of(rule));
-
-    when(ruleService.getRules(isA(UUID.class))).thenReturn(bulkOperationRuleCollection);
-    when(itemClient.getByQuery(isA(String.class))).thenReturn(itemsCollection);
-    doThrow(new RuntimeException("error")).when(itemClient).updateItem(item2, item2.getId());
-    doNothing().when(errorService).saveError(isA(UUID.class), isA(String.class), isA(String.class));
-
-    holdingsUpdateProcessor.updateRecord(holdingsRecord,"identifier", UUID.randomUUID());
-
-    verify(holdingsClient).updateHoldingsRecord(holdingsRecord, holdingsRecord.getId());
-    verify(itemClient).updateItem(item, item.getId());
-    verify(errorService).saveError(isA(UUID.class), isA(String.class), isA(String.class));
-
-    assertTrue(item.getDiscoverySuppress());
-  }
-
-  @Test
-  void shouldUpdateHoldingsRecordWithItemsByDiscoverySupressTrueValueWhenIncludingItemsAction() {
-    var holdingsRecord = new HoldingsRecord()
-      .withId(UUID.randomUUID().toString())
-      .withInstanceId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(true)
-      .withPermanentLocation(new ItemLocation().withId(UUID.randomUUID().toString()));
-    var item = new Item()
-      .withId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(false);
-    var itemsCollection = new ItemCollection().withItems(List.of(item));
-
-    var ruleDetails = new BulkOperationRuleRuleDetails();
-    ruleDetails.setOption(SUPPRESS_FROM_DISCOVERY);
-    var action = new Action();
-    action.setType(SET_TO_TRUE_INCLUDING_ITEMS);
-    ruleDetails.setActions(List.of(action));
-    var rule = new BulkOperationRule();
-    rule.setRuleDetails(ruleDetails);
-    var bulkOperationRuleCollection = new BulkOperationRuleCollection();
-    bulkOperationRuleCollection.setBulkOperationRules(List.of(rule));
-
-    when(ruleService.getRules(isA(UUID.class))).thenReturn(bulkOperationRuleCollection);
-    when(itemClient.getByQuery(isA(String.class))).thenReturn(itemsCollection);
-
-    holdingsUpdateProcessor.updateRecord(holdingsRecord,"identifier", UUID.randomUUID());
-
-    verify(holdingsClient).updateHoldingsRecord(holdingsRecord, holdingsRecord.getId());
-    verify(itemClient).updateItem(item, item.getId());
-
-    assertTrue(item.getDiscoverySuppress());
-  }
-
-  @Test
-  void shouldUpdateHoldingsRecordWithoutItemsByDiscoverySupressTrueValueWhenNotIncludingItemsAction() {
-    var holdingsRecord = new HoldingsRecord()
-      .withId(UUID.randomUUID().toString())
-      .withInstanceId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(true)
-      .withPermanentLocation(new ItemLocation().withId(UUID.randomUUID().toString()));
-    var item = new Item()
-      .withId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(false);
-
-    var ruleDetails = new BulkOperationRuleRuleDetails();
-    ruleDetails.setOption(SUPPRESS_FROM_DISCOVERY);
-    var action = new Action();
-    action.setType(SET_TO_TRUE);
-    ruleDetails.setActions(List.of(action));
-    var rule = new BulkOperationRule();
-    rule.setRuleDetails(ruleDetails);
-    var bulkOperationRuleCollection = new BulkOperationRuleCollection();
-    bulkOperationRuleCollection.setBulkOperationRules(List.of(rule));
-
-    when(ruleService.getRules(isA(UUID.class))).thenReturn(bulkOperationRuleCollection);
-
-    holdingsUpdateProcessor.updateRecord(holdingsRecord,"identifier", UUID.randomUUID());
-
-    verify(holdingsClient).updateHoldingsRecord(holdingsRecord, holdingsRecord.getId());
-    verify(itemClient, times(0)).getByQuery(isA(String.class));
-    verify(itemClient, times(0)).updateItem(item, item.getId());
-
-    assertFalse(item.getDiscoverySuppress());
-  }
-
-  @Test
-  void shouldUpdateHoldingsRecordWithItemsByDiscoverySupressFalseValueWhenIncludingItemsAction() {
-    var holdingsRecord = new HoldingsRecord()
-      .withId(UUID.randomUUID().toString())
-      .withInstanceId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(false)
-      .withPermanentLocation(new ItemLocation().withId(UUID.randomUUID().toString()));
-    var item = new Item()
-      .withId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(true);
-    var itemsCollection = new ItemCollection().withItems(List.of(item));
-
-    var ruleDetails = new BulkOperationRuleRuleDetails();
-    ruleDetails.setOption(SUPPRESS_FROM_DISCOVERY);
-    var action = new Action();
-    action.setType(SET_TO_FALSE_INCLUDING_ITEMS);
-    ruleDetails.setActions(List.of(action));
-    var rule = new BulkOperationRule();
-    rule.setRuleDetails(ruleDetails);
-    var bulkOperationRuleCollection = new BulkOperationRuleCollection();
-    bulkOperationRuleCollection.setBulkOperationRules(List.of(rule));
-
-    when(ruleService.getRules(isA(UUID.class))).thenReturn(bulkOperationRuleCollection);
-    when(itemClient.getByQuery(isA(String.class))).thenReturn(itemsCollection);
-
-    holdingsUpdateProcessor.updateRecord(holdingsRecord,"identifier", UUID.randomUUID());
-
-    verify(holdingsClient).updateHoldingsRecord(holdingsRecord, holdingsRecord.getId());
-    verify(itemClient).updateItem(item, item.getId());
-
-    assertFalse(item.getDiscoverySuppress());
-  }
-
-  @Test
-  void shouldUpdateHoldingsRecordWithoutItemsByDiscoverySupressFalseValueWhenNotIncludingItemsAction() {
-    var holdingsRecord = new HoldingsRecord()
-      .withId(UUID.randomUUID().toString())
-      .withInstanceId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(false)
-      .withPermanentLocation(new ItemLocation().withId(UUID.randomUUID().toString()));
-    var item = new Item()
-      .withId(UUID.randomUUID().toString())
-      .withDiscoverySuppress(true);
-
-    var ruleDetails = new BulkOperationRuleRuleDetails();
-    ruleDetails.setOption(SUPPRESS_FROM_DISCOVERY);
-    var action = new Action();
-    action.setType(SET_TO_FALSE);
-    ruleDetails.setActions(List.of(action));
-    var rule = new BulkOperationRule();
-    rule.setRuleDetails(ruleDetails);
-    var bulkOperationRuleCollection = new BulkOperationRuleCollection();
-    bulkOperationRuleCollection.setBulkOperationRules(List.of(rule));
-
-    when(ruleService.getRules(isA(UUID.class))).thenReturn(bulkOperationRuleCollection);
-
-    holdingsUpdateProcessor.updateRecord(holdingsRecord,"identifier", UUID.randomUUID());
-
-    verify(holdingsClient).updateHoldingsRecord(holdingsRecord, holdingsRecord.getId());
-    verify(itemClient, times(0)).getByQuery(isA(String.class));
-    verify(itemClient, times(0)).updateItem(item, item.getId());
-
-    assertTrue(item.getDiscoverySuppress());
   }
 
   @Test


### PR DESCRIPTION
[MODBULKOPS-126](https://issues.folio.org/browse/MODBULKOPS-126) - Apply to item records when item suppression status differs from holding record

## Purpose
Apply changes to the item records when their suppression status differs from holdings record and provide meaning full message to the user

## Approach
* Updated holdings processor validator and commit logic 
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
