### PR TITLE
MODBULKOPS-196 -  Updating Suppress from discovery flag

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -133,7 +133,8 @@
             "inventory-storage.nature-of-content-terms.item.get",
             "inventory-storage.instance-formats.collection.get",
             "inventory-storage.instance-formats.item.get",
-            "inventory-storage.instances.item.put"
+            "inventory-storage.instances.item.put",
+            "source-storage.records.update"
           ]
         },
         {
@@ -416,6 +417,10 @@
     {
       "id": "instance-formats",
       "version": "2.0"
+    },
+    {
+      "id": "source-storage-records",
+      "version": "3.1"
     }
   ],
   "launchDescriptor": {

--- a/src/main/java/org/folio/bulkops/client/HoldingsClient.java
+++ b/src/main/java/org/folio/bulkops/client/HoldingsClient.java
@@ -22,6 +22,6 @@ public interface HoldingsClient {
   void updateHoldingsRecord(@RequestBody HoldingsRecord holdingsRecord, @PathVariable String holdingsId);
 
   @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-  HoldingsRecordCollection getByQuery(@RequestParam String query, @RequestParam long offset, @RequestParam long limit);
+  HoldingsRecordCollection getByQuery(@RequestParam String query, @RequestParam long limit);
 
 }

--- a/src/main/java/org/folio/bulkops/client/SRSRecordsClient.java
+++ b/src/main/java/org/folio/bulkops/client/SRSRecordsClient.java
@@ -1,0 +1,14 @@
+package org.folio.bulkops.client;
+
+import org.folio.bulkops.configs.FeignClientConfiguration;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "source-storage/records", configuration = FeignClientConfiguration.class)
+public interface SRSRecordsClient {
+  @PutMapping(value = "/{id}/suppress-from-discovery", produces = MediaType.TEXT_PLAIN_VALUE)
+  String setSuppressFromDiscovery(@PathVariable String id, @RequestParam("idType") String idType, @RequestParam("suppress") boolean suppress);
+}

--- a/src/main/java/org/folio/bulkops/domain/bean/Instance.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/Instance.java
@@ -198,11 +198,17 @@ public class Instance implements BulkOperationsEntity {
   private String statusUpdatedDate;
   @JsonProperty("tags")
   private Tags tags;
+  @JsonProperty("ISBN")
+  private String isbn;
+  @JsonProperty("ISSN")
+  private String issn;
 
   @Override
   public String getIdentifier(IdentifierType identifierType) {
     return switch (identifierType) {
       case HRID -> hrid;
+      case ISBN -> isbn;
+      case ISSN -> issn;
       default -> id;
     };
   }

--- a/src/main/java/org/folio/bulkops/processor/AbstractUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractUpdateProcessor.java
@@ -1,0 +1,24 @@
+package org.folio.bulkops.processor;
+
+import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
+
+import lombok.extern.log4j.Log4j2;
+import org.folio.bulkops.domain.bean.BulkOperationsEntity;
+import org.folio.bulkops.domain.entity.BulkOperation;
+import org.folio.bulkops.service.ErrorService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+public abstract class AbstractUpdateProcessor<T extends BulkOperationsEntity> implements UpdateProcessor<T> {
+  @Autowired
+  private ErrorService errorService;
+
+  @Override
+  public void updateAssociatedRecords(T t, BulkOperation operation, boolean notChanged) {
+    if (notChanged) {
+      errorService.saveError(operation.getId(), t.getIdentifier(operation.getIdentifierType()), MSG_NO_CHANGE_REQUIRED);
+    }
+  }
+}

--- a/src/main/java/org/folio/bulkops/processor/HoldingsUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/HoldingsUpdateProcessor.java
@@ -1,25 +1,85 @@
 package org.folio.bulkops.processor;
 
+import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
+import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_FALSE_INCLUDING_ITEMS;
+import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_TRUE_INCLUDING_ITEMS;
+import static org.folio.bulkops.domain.dto.UpdateOptionType.SUPPRESS_FROM_DISCOVERY;
+import static org.folio.bulkops.util.Constants.GET_ITEMS_BY_HOLDING_ID_QUERY;
+import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
+import static org.folio.bulkops.util.RuleUtils.findRuleByOption;
+
 import org.folio.bulkops.client.HoldingsClient;
+import org.folio.bulkops.client.ItemClient;
 import org.folio.bulkops.domain.bean.HoldingsRecord;
+import org.folio.bulkops.domain.bean.Item;
+import org.folio.bulkops.domain.dto.Action;
+import org.folio.bulkops.domain.dto.BulkOperationRule;
+import org.folio.bulkops.domain.entity.BulkOperation;
+import org.folio.bulkops.service.ErrorService;
 import org.folio.bulkops.service.RuleService;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
-import java.util.UUID;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
-public class HoldingsUpdateProcessor implements UpdateProcessor<HoldingsRecord> {
+public class HoldingsUpdateProcessor extends AbstractUpdateProcessor<HoldingsRecord> {
+  private static final String ERROR_MESSAGE_TEMPLATE = "No change in value for holdings record required, associated %s item(s) have been updated.";
+
   private final HoldingsClient holdingsClient;
+  private final ItemClient itemClient;
   private final RuleService ruleService;
+  private final ErrorService errorService;
 
   @Override
-  public void updateRecord(HoldingsRecord holdingsRecord, String identifier, UUID operationId) {
-    holdingsClient.updateHoldingsRecord(holdingsRecord.withInstanceHrid(null)
-        .withItemBarcode(null)
-        .withInstanceTitle(null), holdingsRecord.getId());
+  public void updateRecord(HoldingsRecord holdingsRecord) {
+    holdingsClient.updateHoldingsRecord(
+      holdingsRecord.withInstanceHrid(null).withItemBarcode(null).withInstanceTitle(null),
+      holdingsRecord.getId()
+    );
+  }
+
+  @Override
+  public void updateAssociatedRecords(HoldingsRecord holdingsRecord, BulkOperation operation, boolean notChanged) {
+    boolean itemsUpdated = findRuleByOption(ruleService.getRules(operation.getId()), SUPPRESS_FROM_DISCOVERY)
+      .filter(bulkOperationRule -> suppressItemsIfRequired(holdingsRecord, bulkOperationRule))
+      .isPresent();
+    if (notChanged) {
+      var errorMessage = buildErrorMessage(itemsUpdated, holdingsRecord.getDiscoverySuppress());
+      errorService.saveError(operation.getId(), holdingsRecord.getIdentifier(operation.getIdentifierType()), errorMessage);
+    }
+  }
+
+  private boolean shouldUpdateDiscoverySuppressForItems(BulkOperationRule rule) {
+    return rule.getRuleDetails().getActions().stream()
+      .map(Action::getType)
+      .anyMatch(actionType -> Set.of(SET_TO_TRUE_INCLUDING_ITEMS, SET_TO_FALSE_INCLUDING_ITEMS).contains(actionType));
+  }
+
+  private boolean suppressItemsIfRequired(HoldingsRecord holdingsRecord, BulkOperationRule rule) {
+    List<Item> itemsForUpdate = shouldUpdateDiscoverySuppressForItems(rule) ?
+      itemClient.getByQuery(format(GET_ITEMS_BY_HOLDING_ID_QUERY, holdingsRecord.getId()), Integer.MAX_VALUE)
+        .getItems().stream()
+        .filter(item -> !holdingsRecord.getDiscoverySuppress().equals(item.getDiscoverySuppress()))
+        .toList() :
+      Collections.emptyList();
+    if (itemsForUpdate.isEmpty()) {
+      return false;
+    }
+    itemsForUpdate.forEach(item -> itemClient.updateItem(item.withDiscoverySuppress(holdingsRecord.getDiscoverySuppress()), item.getId()));
+    return true;
+  }
+
+  private String buildErrorMessage(boolean itemsUpdated, boolean newValue) {
+    var affectedState = TRUE.equals(newValue) ? "unsuppressed" : "suppressed";
+    return itemsUpdated ?
+      format(ERROR_MESSAGE_TEMPLATE, affectedState) :
+      MSG_NO_CHANGE_REQUIRED;
   }
 
   @Override

--- a/src/main/java/org/folio/bulkops/processor/InstanceUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/InstanceUpdateProcessor.java
@@ -1,20 +1,127 @@
 package org.folio.bulkops.processor;
 
+import static java.lang.Boolean.TRUE;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.String.format;
+import static org.folio.bulkops.domain.dto.UpdateOptionType.SUPPRESS_FROM_DISCOVERY;
+import static org.folio.bulkops.util.Constants.APPLY_TO_HOLDINGS;
+import static org.folio.bulkops.util.Constants.APPLY_TO_ITEMS;
+import static org.folio.bulkops.util.Constants.GET_HOLDINGS_BY_INSTANCE_ID_QUERY;
+import static org.folio.bulkops.util.Constants.GET_ITEMS_BY_HOLDING_ID_QUERY;
+import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
+import static org.folio.bulkops.util.RuleUtils.fetchParameters;
+import static org.folio.bulkops.util.RuleUtils.findRuleByOption;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.folio.bulkops.client.HoldingsClient;
 import org.folio.bulkops.client.InstanceStorageClient;
+import org.folio.bulkops.client.ItemClient;
+import org.folio.bulkops.client.SRSRecordsClient;
+import org.folio.bulkops.domain.bean.HoldingsRecord;
 import org.folio.bulkops.domain.bean.Instance;
+import org.folio.bulkops.domain.bean.Item;
+import org.folio.bulkops.domain.bean.ItemCollection;
+import org.folio.bulkops.domain.dto.BulkOperationRule;
+import org.folio.bulkops.domain.entity.BulkOperation;
+import org.folio.bulkops.service.ErrorService;
+import org.folio.bulkops.service.RuleService;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
+import java.util.Collections;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class InstanceUpdateProcessor implements UpdateProcessor<Instance> {
+@Slf4j
+public class InstanceUpdateProcessor extends AbstractUpdateProcessor<Instance> {
+  private static final String ERROR_MESSAGE_TEMPLATE = "No change in value for instance required, %s associated records have been updated.";
+
   private final InstanceStorageClient instanceStorageClient;
+  private final RuleService ruleService;
+  private final SRSRecordsClient srsRecordsClient;
+  private final HoldingsClient holdingsClient;
+  private final ItemClient itemClient;
+  private final ErrorService errorService;
 
   @Override
-  public void updateRecord(Instance instance, String identifier, UUID operationId) {
-    instanceStorageClient.updateInstance(instance, instance.getId());
+  public void updateRecord(Instance instance) {
+    instanceStorageClient.updateInstance(instance.withIsbn(null).withIssn(null), instance.getId());
+  }
+
+  @Override
+  public void updateAssociatedRecords(Instance instance, BulkOperation operation, boolean notChanged) {
+    var recordsUpdated = findRuleByOption(ruleService.getRules(operation.getId()), SUPPRESS_FROM_DISCOVERY)
+      .filter(rule -> applyRuleToAssociatedRecords(instance, rule))
+      .isPresent();
+    if (notChanged) {
+      var errorMessage = buildErrorMessage(recordsUpdated, instance.getDiscoverySuppress());
+      errorService.saveError(operation.getId(), instance.getIdentifier(operation.getIdentifierType()), errorMessage);
+    }
+  }
+
+  private boolean applyRuleToAssociatedRecords(Instance instance, BulkOperationRule rule) {
+    var srsUpdated = suppressSRSRecordIfRequired(instance);
+    var parameters = fetchParameters(rule);
+    var shouldApplyToHoldings = parseBoolean(parameters.get(APPLY_TO_HOLDINGS));
+    var shouldApplyToItems = parseBoolean(parameters.get(APPLY_TO_ITEMS));
+    boolean holdingsUpdated = false;
+    boolean itemsUpdated = false;
+    if (shouldApplyToHoldings || shouldApplyToItems) {
+      log.info("Should update associated records: holdings={}, items={}", shouldApplyToHoldings, shouldApplyToItems);
+      var holdings = holdingsClient.getByQuery(format(GET_HOLDINGS_BY_INSTANCE_ID_QUERY, instance.getId()), Integer.MAX_VALUE).getHoldingsRecords();
+      holdingsUpdated = suppressHoldingsIfRequired(holdings, shouldApplyToHoldings, instance.getDiscoverySuppress());
+      itemsUpdated = suppressItemsIfRequired(holdings, shouldApplyToItems, instance.getDiscoverySuppress());
+    }
+    return srsUpdated || holdingsUpdated || itemsUpdated;
+  }
+
+  private boolean suppressSRSRecordIfRequired(Instance instance) {
+    if ("MARC".equals(instance.getSource())) {
+      srsRecordsClient.setSuppressFromDiscovery(instance.getId(), "INSTANCE", instance.getDiscoverySuppress());
+      log.info("Updated underlying SRS record for instance {}: suppress from discovery -> {}", instance.getId(), instance.getDiscoverySuppress());
+      return true;
+    }
+    return false;
+  }
+
+  private boolean suppressHoldingsIfRequired(List<HoldingsRecord> holdingsRecords, boolean applyToHoldings, boolean suppress) {
+    List<HoldingsRecord> holdingsForUpdate = applyToHoldings ?
+      holdingsRecords.stream()
+        .filter(holdingsRecord -> holdingsRecord.getDiscoverySuppress() != suppress)
+        .toList() :
+      Collections.emptyList();
+    log.info("Found {} holdings for update", holdingsForUpdate.size());
+    if (holdingsForUpdate.isEmpty()) {
+      return false;
+    }
+    holdingsForUpdate.forEach(holdingsRecord -> holdingsClient.updateHoldingsRecord(holdingsRecord.withDiscoverySuppress(suppress), holdingsRecord.getId()));
+    return true;
+  }
+
+  private boolean suppressItemsIfRequired(List<HoldingsRecord> holdingsRecords, boolean applyToItems, boolean suppress) {
+    List<Item> itemsForUpdate = applyToItems ?
+      holdingsRecords.stream()
+        .map(HoldingsRecord::getId)
+        .map(id -> itemClient.getByQuery(format(GET_ITEMS_BY_HOLDING_ID_QUERY, id), Integer.MAX_VALUE))
+        .map(ItemCollection::getItems)
+        .flatMap(List::stream)
+        .filter(item -> suppress == item.getDiscoverySuppress())
+        .toList() :
+      Collections.emptyList();
+    log.info("Found {} items for update", itemsForUpdate.size());
+    if (itemsForUpdate.isEmpty()) {
+      return false;
+    }
+    itemsForUpdate.forEach(item -> itemClient.updateItem(item.withDiscoverySuppress(suppress), item.getId()));
+    return true;
+  }
+
+  private String buildErrorMessage(boolean recordsUpdated, boolean newValue) {
+    var affectedState = TRUE.equals(newValue) ? "unsuppressed" : "suppressed";
+    return recordsUpdated ?
+      format(ERROR_MESSAGE_TEMPLATE, affectedState) :
+      MSG_NO_CHANGE_REQUIRED;
   }
 
   @Override

--- a/src/main/java/org/folio/bulkops/processor/ItemUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/ItemUpdateProcessor.java
@@ -6,15 +6,13 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
-import java.util.UUID;
-
 @Component
 @RequiredArgsConstructor
-public class ItemUpdateProcessor implements UpdateProcessor<Item> {
+public class ItemUpdateProcessor extends AbstractUpdateProcessor<Item> {
   private final ItemClient itemClient;
 
   @Override
-  public void updateRecord(Item item, String identifier, UUID operationId) {
+  public void updateRecord(Item item) {
     itemClient.updateItem(item, item.getId());
   }
 

--- a/src/main/java/org/folio/bulkops/processor/UpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/UpdateProcessor.java
@@ -1,8 +1,11 @@
 package org.folio.bulkops.processor;
 
-import java.util.UUID;
+import org.folio.bulkops.domain.entity.BulkOperation;
 
 public interface UpdateProcessor<T> {
-  void updateRecord(T t, String identifier,  UUID operationId);
+  void updateRecord(T t);
+
+  void updateAssociatedRecords(T t, BulkOperation bulkOperation, boolean notChanged);
+
   Class<T> getUpdatedType();
 }

--- a/src/main/java/org/folio/bulkops/processor/UserUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/UserUpdateProcessor.java
@@ -6,15 +6,13 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
-import java.util.UUID;
-
 @Component
 @RequiredArgsConstructor
-public class UserUpdateProcessor implements UpdateProcessor<User> {
+public class UserUpdateProcessor extends AbstractUpdateProcessor<User> {
   private final UserClient userClient;
 
   @Override
-  public void updateRecord(User user, String identifier, UUID operationId) {
+  public void updateRecord(User user) {
     userClient.updateUser(user, user.getId());
   }
 

--- a/src/main/java/org/folio/bulkops/service/RecordUpdateService.java
+++ b/src/main/java/org/folio/bulkops/service/RecordUpdateService.java
@@ -1,0 +1,35 @@
+package org.folio.bulkops.service;
+
+import static org.folio.bulkops.util.Utils.resolveEntityClass;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.bulkops.domain.bean.BulkOperationsEntity;
+import org.folio.bulkops.domain.bean.StateType;
+import org.folio.bulkops.domain.entity.BulkOperation;
+import org.folio.bulkops.domain.entity.BulkOperationExecutionContent;
+import org.folio.bulkops.processor.UpdateProcessorFactory;
+import org.folio.bulkops.repository.BulkOperationExecutionContentRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecordUpdateService {
+  private final UpdateProcessorFactory updateProcessorFactory;
+  private final BulkOperationExecutionContentRepository executionContentRepository;
+
+  public BulkOperationsEntity updateEntity(BulkOperationsEntity original, BulkOperationsEntity modified, BulkOperation operation) {
+    var isEqual = original.hashCode() == modified.hashCode() && original.equals(modified);
+    var updater = updateProcessorFactory.getProcessorFromFactory(resolveEntityClass(operation.getEntityType()));
+    if (!isEqual) {
+      updater.updateRecord(modified);
+      executionContentRepository.save(BulkOperationExecutionContent.builder()
+        .bulkOperationId(operation.getId())
+        .identifier(modified.getIdentifier(operation.getIdentifierType()))
+        .state(StateType.PROCESSED)
+        .build());
+      operation.setCommittedNumOfRecords(operation.getCommittedNumOfRecords() + 1);
+    }
+    updater.updateAssociatedRecords(modified, operation, isEqual);
+    return isEqual ? original : modified;
+  }
+}

--- a/src/main/java/org/folio/bulkops/service/RuleService.java
+++ b/src/main/java/org/folio/bulkops/service/RuleService.java
@@ -1,7 +1,6 @@
 package org.folio.bulkops.service;
 
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.folio.bulkops.domain.dto.Action;
 import org.folio.bulkops.domain.dto.BulkOperationRule;
@@ -10,6 +9,7 @@ import org.folio.bulkops.domain.dto.BulkOperationRuleRuleDetails;
 import org.folio.bulkops.exception.NotFoundException;
 import org.folio.bulkops.repository.BulkOperationRuleDetailsRepository;
 import org.folio.bulkops.repository.BulkOperationRuleRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,10 +45,11 @@ public class RuleService {
     return ruleCollection;
   }
 
+  @Cacheable(cacheNames = "rules")
   public BulkOperationRuleCollection getRules(UUID bulkOperationId) {
     var rules = ruleRepository.findAllByBulkOperationId(bulkOperationId).stream()
       .map(this::mapBulkOperationRuleToDto)
-      .collect(Collectors.toList());
+      .toList();
     if (rules.isEmpty()) {
       throw new NotFoundException("Bulk operation rules were not found by bulk operation id=" + bulkOperationId);
     }
@@ -66,6 +67,6 @@ public class RuleService {
             .initial(details.getInitialValue())
             .updated(details.getUpdatedValue())
             .parameters(details.getParameters()))
-          .collect(Collectors.toList())));
+          .toList()));
   }
 }

--- a/src/main/java/org/folio/bulkops/util/Constants.java
+++ b/src/main/java/org/folio/bulkops/util/Constants.java
@@ -46,4 +46,8 @@ public class Constants {
   public static final String STAFF_ONLY = "(staff only)";
   public static final String ADMINISTRATIVE_NOTES = "Administrative Notes";
   public static final String ADMINISTRATIVE_NOTE = "Administrative Note";
+  public static final String GET_ITEMS_BY_HOLDING_ID_QUERY = "holdingsRecordId==%s";
+  public static final String GET_HOLDINGS_BY_INSTANCE_ID_QUERY = "instanceId==%s";
+  public static final String APPLY_TO_HOLDINGS = "APPLY_TO_HOLDINGS";
+  public static final String APPLY_TO_ITEMS = "APPLY_TO_ITEMS";
 }

--- a/src/main/java/org/folio/bulkops/util/RuleUtils.java
+++ b/src/main/java/org/folio/bulkops/util/RuleUtils.java
@@ -1,0 +1,31 @@
+package org.folio.bulkops.util;
+
+import lombok.experimental.UtilityClass;
+import org.folio.bulkops.domain.dto.Action;
+import org.folio.bulkops.domain.dto.BulkOperationRule;
+import org.folio.bulkops.domain.dto.BulkOperationRuleCollection;
+import org.folio.bulkops.domain.dto.Parameter;
+import org.folio.bulkops.domain.dto.UpdateOptionType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@UtilityClass
+public class RuleUtils {
+  public static Optional<BulkOperationRule> findRuleByOption(BulkOperationRuleCollection rules, UpdateOptionType option) {
+    return rules.getBulkOperationRules().stream()
+      .filter(rule -> option.equals(rule.getRuleDetails().getOption()))
+      .findFirst();
+  }
+
+  public static Map<String, String> fetchParameters(BulkOperationRule rule) {
+    return rule.getRuleDetails().getActions().stream()
+      .map(Action::getParameters)
+      .filter(Objects::nonNull)
+      .flatMap(List::stream)
+      .collect(Collectors.toMap(Parameter::getKey, Parameter::getValue, (existing, replacement) -> existing));
+  }
+}

--- a/src/test/java/org/folio/bulkops/service/RecordUpdateServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/RecordUpdateServiceTest.java
@@ -1,0 +1,76 @@
+package org.folio.bulkops.service;
+
+import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.folio.bulkops.BaseTest;
+import org.folio.bulkops.domain.bean.Item;
+import org.folio.bulkops.domain.dto.EntityType;
+import org.folio.bulkops.domain.dto.IdentifierType;
+import org.folio.bulkops.domain.entity.BulkOperation;
+import org.folio.bulkops.processor.ItemUpdateProcessor;
+import org.folio.bulkops.repository.BulkOperationExecutionContentRepository;
+import org.folio.bulkops.repository.BulkOperationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.util.UUID;
+
+class RecordUpdateServiceTest extends BaseTest {
+  @Autowired
+  private RecordUpdateService recordUpdateService;
+  @MockBean
+  private BulkOperationExecutionContentRepository executionContentRepository;
+  @MockBean
+  private BulkOperationRepository bulkOperationRepository;
+  @SpyBean
+  private ItemUpdateProcessor itemUpdateProcessor;
+  @SpyBean
+  private ErrorService errorService;
+
+  @Test
+  void testUpdateNonEqualEntity() {
+    var original = Item.builder()
+      .id(UUID.randomUUID().toString())
+      .barcode("barcode")
+      .build();
+    var modified = original.withCallNumber("call number");
+    var operation = BulkOperation.builder()
+      .id(UUID.randomUUID())
+      .identifierType(IdentifierType.ID)
+      .entityType(EntityType.ITEM)
+      .build();
+
+    var result = recordUpdateService.updateEntity(original, modified, operation);
+
+    assertEquals(modified, result);
+    verify(itemUpdateProcessor).updateRecord(any(Item.class));
+    verify(errorService, times(0)).saveError(any(UUID.class), anyString(), anyString());
+  }
+
+  @Test
+  void testUpdateNonModifiedEntity() {
+    var original = Item.builder()
+      .id(UUID.randomUUID().toString())
+      .barcode("barcode")
+      .build();
+    var modified = original;
+    var operation = BulkOperation.builder()
+      .id(UUID.randomUUID())
+      .identifierType(IdentifierType.ID)
+      .entityType(EntityType.ITEM)
+      .build();
+
+    var result = recordUpdateService.updateEntity(original, modified, operation);
+
+    assertEquals(original, result);
+    verify(itemUpdateProcessor, times(0)).updateRecord(any(Item.class));
+    verify(errorService).saveError(operation.getId(), original.getIdentifier(IdentifierType.ID), MSG_NO_CHANGE_REQUIRED);
+  }
+}


### PR DESCRIPTION
[MODBULKOPS-196](https://issues.folio.org/browse/MODBULKOPS-196) -  Updating Suppress from discovery flag

## Purpose
Bulk update the value of Suppress from discovery flag in instance records

## Approach
* Implemented logic
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
