### PR TITLE
MODBULKOPS-196 -  Updating Suppress from discovery flag

### DIFF
--- a/src/main/java/org/folio/bulkops/processor/InstanceUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/InstanceUpdateProcessor.java
@@ -106,7 +106,7 @@ public class InstanceUpdateProcessor extends AbstractUpdateProcessor<Instance> {
         .map(id -> itemClient.getByQuery(format(GET_ITEMS_BY_HOLDING_ID_QUERY, id), Integer.MAX_VALUE))
         .map(ItemCollection::getItems)
         .flatMap(List::stream)
-        .filter(item -> suppress == item.getDiscoverySuppress())
+        .filter(item -> suppress != item.getDiscoverySuppress())
         .toList() :
       Collections.emptyList();
     log.info("Found {} items for update", itemsForUpdate.size());

--- a/src/main/resources/swagger.api/schemas/action.json
+++ b/src/main/resources/swagger.api/schemas/action.json
@@ -20,8 +20,7 @@
         "type": "array",
         "items": {
           "$ref": "action_parameter.json#/Parameter"
-        },
-        "minItems": 1
+        }
       }
     },
     "required": [

--- a/src/test/java/org/folio/bulkops/processor/UpdateProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/UpdateProcessorTest.java
@@ -128,10 +128,10 @@ class UpdateProcessorTest extends BaseTest {
 
   @ParameterizedTest
   @CsvSource(textBlock = """
-    SET_TO_TRUE_INCLUDING_ITEMS   | false
-    SET_TO_FALSE_INCLUDING_ITEMS  | false
-    SET_TO_TRUE_INCLUDING_ITEMS   | true
-    SET_TO_FALSE_INCLUDING_ITEMS  | true
+    SET_TO_TRUE   | false
+    SET_TO_FALSE  | false
+    SET_TO_TRUE   | true
+    SET_TO_FALSE  | true
     """, delimiter = '|')
   void holdings_shouldUpdateAssociatedItemsDiscoverySuppress(UpdateActionType actionType, boolean notChanged) {
     var holdingsId = UUID.randomUUID().toString();
@@ -148,7 +148,11 @@ class UpdateProcessorTest extends BaseTest {
 
     var rule = new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails()
       .option(UpdateOptionType.SUPPRESS_FROM_DISCOVERY)
-      .actions(Collections.singletonList(new Action().type(actionType))));
+      .actions(Collections.singletonList(new Action()
+        .type(actionType)
+        .parameters(Collections.singletonList(new Parameter()
+          .key(APPLY_TO_ITEMS)
+          .value("true"))))));
     when(ruleService.getRules(operationId)).thenReturn(new BulkOperationRuleCollection()
       .bulkOperationRules(Collections.singletonList(rule))
       .totalRecords(1));

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -5,6 +5,7 @@ import static org.folio.bulkops.domain.dto.EntityType.HOLDINGS_RECORD;
 import static org.folio.bulkops.domain.dto.EntityType.ITEM;
 import static org.folio.bulkops.util.Constants.ADMINISTRATIVE_NOTE;
 import static org.folio.bulkops.util.Constants.ADMINISTRATIVE_NOTES;
+import static org.folio.bulkops.util.Constants.APPLY_TO_ITEMS;
 import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
 import static org.folio.bulkops.util.UnifiedTableHeaderBuilder.getHeaders;
 import static org.folio.bulkops.domain.dto.BulkOperationStep.COMMIT;
@@ -43,6 +44,7 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -77,6 +79,7 @@ import org.folio.bulkops.domain.dto.Cell;
 import org.folio.bulkops.domain.dto.EntityType;
 import org.folio.bulkops.domain.dto.IdentifierType;
 import org.folio.bulkops.domain.dto.OperationStatusType;
+import org.folio.bulkops.domain.dto.Parameter;
 import org.folio.bulkops.domain.dto.Row;
 import org.folio.bulkops.domain.dto.UpdateActionType;
 import org.folio.bulkops.domain.dto.UpdateOptionType;
@@ -1104,7 +1107,11 @@ class BulkOperationServiceTest extends BaseTest {
         .bulkOperationRules(List.of(new BulkOperationRule()
           .ruleDetails(new BulkOperationRuleRuleDetails()
             .option(UpdateOptionType.SUPPRESS_FROM_DISCOVERY)
-            .actions(List.of(new Action().type(testData.actionType)))))));
+            .actions(List.of(new Action()
+              .type(testData.actionType)
+              .parameters(Collections.singletonList(new Parameter()
+                .key(APPLY_TO_ITEMS)
+                .value("true")))))))));
     when(itemClient.getByQuery(anyString(), anyInt()))
       .thenReturn(ItemCollection.builder()
         .items(List.of(

--- a/src/test/java/org/folio/bulkops/service/DiscoverySuppressTestData.java
+++ b/src/test/java/org/folio/bulkops/service/DiscoverySuppressTestData.java
@@ -1,7 +1,7 @@
 package org.folio.bulkops.service;
 
-import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_FALSE_INCLUDING_ITEMS;
-import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_TRUE_INCLUDING_ITEMS;
+import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_FALSE;
+import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_TRUE;
 import static org.folio.bulkops.util.Constants.MSG_HOLDING_NO_CHANGE_REQUIRED_SUPPRESSED_ITEMS_UPDATED;
 import static org.folio.bulkops.util.Constants.MSG_HOLDING_NO_CHANGE_REQUIRED_UNSUPPRESSED_ITEMS_UPDATED;
 import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
@@ -11,14 +11,14 @@ import org.folio.bulkops.domain.dto.UpdateActionType;
 
 @RequiredArgsConstructor
 public enum DiscoverySuppressTestData {
-  SET_TRUE_HOLDINGS_SUPPRESSED_ITEMS_SUPPRESSED(SET_TO_TRUE_INCLUDING_ITEMS, true, true,  true, true, 0, MSG_NO_CHANGE_REQUIRED),
-  SET_FALSE_HOLDINGS_SUPPRESSED_ITEMS_SUPPRESSED(SET_TO_FALSE_INCLUDING_ITEMS, true, false, true, true, 2, null),
-  SET_TRUE_HOLDINGS_UNSUPPRESSED_ITEMS_UNSUPPRESSED(SET_TO_TRUE_INCLUDING_ITEMS, false, true,  false, false, 2, null),
-  SET_FALSE_HOLDINGS_UNSUPPRESSED_ITEMS_UNSUPPRESSED(SET_TO_FALSE_INCLUDING_ITEMS, false, false,  false, false, 0, MSG_NO_CHANGE_REQUIRED),
-  SET_TRUE_HOLDINGS_SUPPRESSED_ONE_ITEM_SUPPRESSED(SET_TO_TRUE_INCLUDING_ITEMS, true, true, true, false, 1, MSG_HOLDING_NO_CHANGE_REQUIRED_UNSUPPRESSED_ITEMS_UPDATED),
-  SET_FALSE_HOLDINGS_SUPPRESSED_ONE_ITEM_SUPPRESSED(SET_TO_FALSE_INCLUDING_ITEMS, true, false, true, false, 1, null),
-  SET_TRUE_HOLDINGS_UNSUPPRESSED_ONE_ITEM_UNSUPPRESSED(SET_TO_TRUE_INCLUDING_ITEMS, false, true, true, false, 1, null),
-  SET_FALSE_HOLDINGS_UNSUPPRESSED_ONE_ITEM_UNSUPPRESSED(SET_TO_FALSE_INCLUDING_ITEMS, false, false, true, false, 1, MSG_HOLDING_NO_CHANGE_REQUIRED_SUPPRESSED_ITEMS_UPDATED);
+  SET_TRUE_HOLDINGS_SUPPRESSED_ITEMS_SUPPRESSED(SET_TO_TRUE, true, true,  true, true, 0, MSG_NO_CHANGE_REQUIRED),
+  SET_FALSE_HOLDINGS_SUPPRESSED_ITEMS_SUPPRESSED(SET_TO_FALSE, true, false, true, true, 2, null),
+  SET_TRUE_HOLDINGS_UNSUPPRESSED_ITEMS_UNSUPPRESSED(SET_TO_TRUE, false, true,  false, false, 2, null),
+  SET_FALSE_HOLDINGS_UNSUPPRESSED_ITEMS_UNSUPPRESSED(SET_TO_FALSE, false, false,  false, false, 0, MSG_NO_CHANGE_REQUIRED),
+  SET_TRUE_HOLDINGS_SUPPRESSED_ONE_ITEM_SUPPRESSED(SET_TO_TRUE, true, true, true, false, 1, MSG_HOLDING_NO_CHANGE_REQUIRED_UNSUPPRESSED_ITEMS_UPDATED),
+  SET_FALSE_HOLDINGS_SUPPRESSED_ONE_ITEM_SUPPRESSED(SET_TO_FALSE, true, false, true, false, 1, null),
+  SET_TRUE_HOLDINGS_UNSUPPRESSED_ONE_ITEM_UNSUPPRESSED(SET_TO_TRUE, false, true, true, false, 1, null),
+  SET_FALSE_HOLDINGS_UNSUPPRESSED_ONE_ITEM_UNSUPPRESSED(SET_TO_FALSE, false, false, true, false, 1, MSG_HOLDING_NO_CHANGE_REQUIRED_SUPPRESSED_ITEMS_UPDATED);
 
   final UpdateActionType actionType;
   final boolean originalHoldingsDiscoverySuppress;


### PR DESCRIPTION
[MODBULKOPS-196](https://issues.folio.org/browse/MODBULKOPS-196) -  Updating Suppress from discovery flag

## Approach
* Refactored logic for holdings to provide unified approach
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
