### PR TITLE
[UXPROD-3903] Support data-export-spring interface 2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ## v2.0.0 - Unreleased
 
+### Technical tasks
+* [UXPROD-3903](https://folio-org.atlassian.net/browse/UXPROD-3903) - Support `data-export-spring` interface 2.0. Breaking change in `data-export-spring` does not impact mod-bulk-operations use
+
 ## v1.1.0 - Released 2023/10/12
 This release includes file storage optimization, editing for items notes, suppression status, bugs fixes.
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -416,7 +416,7 @@
     },
     {
       "id": "data-export-spring",
-      "version": "1.0"
+      "version": "1.0 2.0"
     },
     {
       "id": "instance-statuses",


### PR DESCRIPTION
# [Jira UXPROD-3903](https://folio-org.atlassian.net/browse/UXPROD-3903)

## Purpose
Work being done by @folio-org/bama in [mod-data-export-spring](https://github.com/folio-org/mod-data-export-spring/pull/270) and related modules necessitated a breaking change in the provided `data-export-spring` interface, bumping its version to `2.0`.  This breaking change has no impact on `mod-bulk-operations`; as such, we can safely update our `ModuleDescriptor` to support this new version.

> [!WARNING]
> This PR **must** be merged before https://github.com/folio-org/mod-data-export-spring/pull/270, otherwise the snapshot environment will break.