### PR TITLE
MODBULKOPS-134 - Preserve the "Staff only" flag when change note type and duplicate note in Items Bulk Edit

### DIFF
--- a/src/main/java/org/folio/bulkops/processor/ItemsNotesUpdater.java
+++ b/src/main/java/org/folio/bulkops/processor/ItemsNotesUpdater.java
@@ -302,14 +302,22 @@ public class ItemsNotesUpdater {
       if (NOTES_TYPES_TO_UPDATE.contains(noteTypeToUse)) {
         if (!notesWithTypeForChange.isEmpty()) {
           var notesWithoutTypeForChange = item.getNotes().stream().filter(note -> !StringUtils.equals(note.getItemNoteTypeId(), noteTypeId)).collect(toCollection(ArrayList::new));
-          if (item.getAdministrativeNotes() == null) item.setAdministrativeNotes(new ArrayList<>());
-          if (item.getCirculationNotes() == null) item.setCirculationNotes(new ArrayList<>());
+          if (item.getAdministrativeNotes() == null) {
+            item.setAdministrativeNotes(new ArrayList<>());
+          }
+          if (item.getCirculationNotes() == null) {
+            item.setCirculationNotes(new ArrayList<>());
+          }
           notesWithTypeForChange.forEach(note -> {
             if (CHECK_IN_NOTE_TYPE.equals(noteTypeToUse))
-              item.getCirculationNotes().add(new CirculationNote().withNoteType(CirculationNote.NoteTypeEnum.IN).withNote(note.getNote()).withStaffOnly(false));
+              item.getCirculationNotes().add(new CirculationNote().withNoteType(CirculationNote.NoteTypeEnum.IN)
+                .withNote(note.getNote()).withStaffOnly(note.getStaffOnly()));
             if (CHECK_OUT_NOTE_TYPE.equals(noteTypeToUse))
-              item.getCirculationNotes().add(new CirculationNote().withNoteType(CirculationNote.NoteTypeEnum.OUT).withNote(note.getNote()).withStaffOnly(false));
-            if (ADMINISTRATIVE_NOTE_TYPE.equals(noteTypeToUse)) item.getAdministrativeNotes().add(note.getNote());
+              item.getCirculationNotes().add(new CirculationNote().withNoteType(CirculationNote.NoteTypeEnum.OUT)
+                .withNote(note.getNote()).withStaffOnly(note.getStaffOnly()));
+            if (ADMINISTRATIVE_NOTE_TYPE.equals(noteTypeToUse)) {
+              item.getAdministrativeNotes().add(note.getNote());
+            }
           });
           item.setNotes(notesWithoutTypeForChange);
         }

--- a/src/main/java/org/folio/bulkops/processor/ItemsNotesUpdater.java
+++ b/src/main/java/org/folio/bulkops/processor/ItemsNotesUpdater.java
@@ -281,13 +281,17 @@ public class ItemsNotesUpdater {
         var circNotesWithoutTypeForChange = item.getCirculationNotes().stream().filter(circulationNote -> circulationNote.getNoteType() != typeForChange).collect(toCollection(ArrayList::new));
         var circNotesWithTypeForChange = item.getCirculationNotes().stream().filter(circulationNote -> circulationNote.getNoteType() == typeForChange).toList();
         if (!circNotesWithTypeForChange.isEmpty()) {
-          if (item.getAdministrativeNotes() == null) item.setAdministrativeNotes(new ArrayList<>());
-          if (item.getNotes() == null) item.setNotes(new ArrayList<>());
+          if (item.getAdministrativeNotes() == null) {
+            item.setAdministrativeNotes(new ArrayList<>());
+          }
+          if (item.getNotes() == null) {
+            item.setNotes(new ArrayList<>());
+          }
           circNotesWithTypeForChange.forEach(note -> {
             if (ADMINISTRATIVE_NOTE_TYPE.equals(noteTypeToUse)) {
               item.getAdministrativeNotes().add(note.getNote());
             } else {
-              item.getNotes().add(new ItemNote().withItemNoteTypeId(noteTypeToUse).withNote(note.getNote()));
+              item.getNotes().add(new ItemNote().withItemNoteTypeId(noteTypeToUse).withNote(note.getNote()).withStaffOnly(note.getStaffOnly()));
             }
           });
           item.setCirculationNotes(circNotesWithoutTypeForChange);

--- a/src/main/java/org/folio/bulkops/processor/ItemsNotesUpdater.java
+++ b/src/main/java/org/folio/bulkops/processor/ItemsNotesUpdater.java
@@ -309,12 +309,14 @@ public class ItemsNotesUpdater {
             item.setCirculationNotes(new ArrayList<>());
           }
           notesWithTypeForChange.forEach(note -> {
-            if (CHECK_IN_NOTE_TYPE.equals(noteTypeToUse))
+            if (CHECK_IN_NOTE_TYPE.equals(noteTypeToUse)) {
               item.getCirculationNotes().add(new CirculationNote().withNoteType(CirculationNote.NoteTypeEnum.IN)
                 .withNote(note.getNote()).withStaffOnly(note.getStaffOnly()));
-            if (CHECK_OUT_NOTE_TYPE.equals(noteTypeToUse))
+            }
+            if (CHECK_OUT_NOTE_TYPE.equals(noteTypeToUse)) {
               item.getCirculationNotes().add(new CirculationNote().withNoteType(CirculationNote.NoteTypeEnum.OUT)
                 .withNote(note.getNote()).withStaffOnly(note.getStaffOnly()));
+            }
             if (ADMINISTRATIVE_NOTE_TYPE.equals(noteTypeToUse)) {
               item.getAdministrativeNotes().add(note.getNote());
             }

--- a/src/test/java/org/folio/bulkops/processor/ItemDataProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/ItemDataProcessorTest.java
@@ -766,9 +766,9 @@ class ItemDataProcessorTest extends BaseTest {
   @SneakyThrows
   void testDuplicateForCirculationNotes() {
     var checkInNote = new CirculationNote().withId(UUID.randomUUID().toString())
-      .withNoteType(CirculationNote.NoteTypeEnum.IN).withNote("note 1");
+      .withNoteType(CirculationNote.NoteTypeEnum.IN).withNote("note 1").withStaffOnly(true);
     var checkOutNote = new CirculationNote().withId(UUID.randomUUID().toString())
-      .withNoteType(CirculationNote.NoteTypeEnum.OUT).withNote("note 2");
+      .withNoteType(CirculationNote.NoteTypeEnum.OUT).withNote("note 2").withStaffOnly(true);
     var item = new Item().withCirculationNotes(new ArrayList<>(List.of(checkInNote, checkOutNote)));
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
@@ -778,6 +778,7 @@ class ItemDataProcessorTest extends BaseTest {
     var duplicated = item.getCirculationNotes().stream().filter(circNote ->
       circNote.getNoteType() == CirculationNote.NoteTypeEnum.OUT && StringUtils.equals(circNote.getNote(), "note 1")).findFirst();
     assertTrue(duplicated.isPresent());
+    assertTrue(duplicated.get().getStaffOnly());
 
     processor.updater(CHECK_OUT_NOTE, new Action().type(DUPLICATE).updated(CHECK_IN_NOTE_TYPE)).apply(item);
     assertEquals(5, item.getCirculationNotes().size());
@@ -787,9 +788,10 @@ class ItemDataProcessorTest extends BaseTest {
       circNote.getNoteType() == CirculationNote.NoteTypeEnum.IN && StringUtils.equals(circNote.getNote(), "note 1")).count();
     assertEquals(2, count);
 
-    count = item.getCirculationNotes().stream().filter(circNote ->
-      circNote.getNoteType() == CirculationNote.NoteTypeEnum.IN && StringUtils.equals(circNote.getNote(), "note 2")).count();
-    assertEquals(1, count);
+    duplicated = item.getCirculationNotes().stream().filter(circNote ->
+      circNote.getNoteType() == CirculationNote.NoteTypeEnum.IN && StringUtils.equals(circNote.getNote(), "note 2")).findFirst();
+    assertTrue(duplicated.isPresent());
+    assertTrue(duplicated.get().getStaffOnly());
   }
 
   @Test

--- a/src/test/java/org/folio/bulkops/processor/ItemDataProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/ItemDataProcessorTest.java
@@ -680,9 +680,9 @@ class ItemDataProcessorTest extends BaseTest {
   @SneakyThrows
   void testChangeNoteTypeForCirculationNotes() {
     var checkInNote = new CirculationNote()
-      .withNoteType(CirculationNote.NoteTypeEnum.IN).withNote("note");
+      .withNoteType(CirculationNote.NoteTypeEnum.IN).withNote("note").withStaffOnly(true);
     var checkOutNote = new CirculationNote()
-      .withNoteType(CirculationNote.NoteTypeEnum.OUT).withNote("note 2");
+      .withNoteType(CirculationNote.NoteTypeEnum.OUT).withNote("note 2").withStaffOnly(true);
     var item = new Item().withCirculationNotes(List.of(checkInNote, checkOutNote));
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
@@ -691,6 +691,7 @@ class ItemDataProcessorTest extends BaseTest {
     assertEquals(2, item.getCirculationNotes().size());
     assertEquals("note", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
+    assertTrue(item.getCirculationNotes().get(0).getStaffOnly());
 
     checkInNote.setNoteType(CirculationNote.NoteTypeEnum.IN);
 
@@ -711,12 +712,13 @@ class ItemDataProcessorTest extends BaseTest {
     assertEquals(1, item.getNotes().size());
     assertEquals("note", item.getNotes().get(0).getNote());
     assertEquals("typeId", item.getNotes().get(0).getItemNoteTypeId());
+    assertTrue(item.getNotes().get(0).getStaffOnly());
   }
 
   @Test
   @SneakyThrows
   void testChangeNoteTypeForItemNotes() {
-    var itemNote1 = new ItemNote().withItemNoteTypeId("typeId1").withNote("itemNote1");
+    var itemNote1 = new ItemNote().withItemNoteTypeId("typeId1").withNote("itemNote1").withStaffOnly(true);
     var itemNote2 = new ItemNote().withItemNoteTypeId("typeId2").withNote("itemNote2");
     var parameter = new Parameter();
     parameter.setKey(ITEM_NOTE_TYPE_ID_KEY);
@@ -738,6 +740,7 @@ class ItemDataProcessorTest extends BaseTest {
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals("itemNote1", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.IN, item.getCirculationNotes().get(0).getNoteType());
+    assertTrue(item.getCirculationNotes().get(0).getStaffOnly());
     assertEquals(1, item.getNotes().size());
     assertEquals("itemNote2", item.getNotes().get(0).getNote());
 
@@ -748,6 +751,7 @@ class ItemDataProcessorTest extends BaseTest {
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals("itemNote1", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
+    assertTrue(item.getCirculationNotes().get(0).getStaffOnly());
     assertEquals(1, item.getNotes().size());
     assertEquals("itemNote2", item.getNotes().get(0).getNote());
 


### PR DESCRIPTION
<!--
   If you have a relevant JIRA issue number, please put it in the issue title.
   Example: MODBULKOPS-1 - Setup mod-bulk-operations module
   TL;DR
     - https://www.youtube.com/watch?v=5aHmO_S8FQ4
     - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
     - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
 -->
[MODBULKOPS-134](https://folio-org.atlassian.net/browse/MODBULKOPS-134) - Preserve the "Staff only" flag when change note type and duplicate note in Items Bulk Edit
## Purpose
 <!--
   Why are you making this change? There is nothing more important
   to provide to the reviewer and to future readers than the cause
   that gave rise to this pull request. Be careful to avoid circular
   statements like "the purpose is to update the schema." and
   instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
   which is currently missing in the schema"
   The purpose may seem self-evident to you now, but the standard to
   hold yourself to should be "can a developer parachuting into this
   project reconstruct the necessary context merely by reading this
   section."
   If you have a relevant JIRA issue, add a link directly to the issue URL here.
   Example: https://issues.folio.org/browse/MODQM-3
  -->

## Approach
 <!--
  How does this change fulfill the purpose? It's best to talk
  high-level strategy and avoid code-splaining the commit history.
  The goal is not only to explain what you did, but help other
  developers *work* with your solution in the future.
 -->

### TODOS and Open Questions
 <!-- OPTIONAL
 - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
 -->

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
