### PR TITLE
MODBULKOPS-279 - FQM flow: tenant information populating

### DIFF
--- a/src/main/java/org/folio/bulkops/client/QueryClient.java
+++ b/src/main/java/org/folio/bulkops/client/QueryClient.java
@@ -23,5 +23,5 @@ public interface QueryClient {
   QueryDetails getQuery(@RequestHeader UUID queryId);
 
   @GetMapping("/{queryId}/sortedIds")
-  List<List<UUID>> getSortedIds(@RequestHeader UUID queryId, @RequestParam Integer offset, @RequestParam Integer limit);
+  List<List<String>> getSortedIds(@RequestHeader UUID queryId, @RequestParam Integer offset, @RequestParam Integer limit);
 }

--- a/src/main/java/org/folio/bulkops/service/QueryService.java
+++ b/src/main/java/org/folio/bulkops/service/QueryService.java
@@ -60,9 +60,8 @@ public class QueryService {
   private void saveIdentifiers(BulkOperation bulkOperation) {
     try {
       var identifiersString = queryClient.getSortedIds(bulkOperation.getFqlQueryId(), 0, Integer.MAX_VALUE).stream()
-        .flatMap(List::stream)
+        .map(list -> list.get(0))
         .distinct()
-        .map(UUID::toString)
         .collect(Collectors.joining(NEW_LINE_SEPARATOR));
       var path = String.format(QUERY_FILENAME_TEMPLATE, bulkOperation.getId());
       remoteFileSystemClient.put(new ByteArrayInputStream(identifiersString.getBytes()), path);

--- a/src/test/java/org/folio/bulkops/service/QueryServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/QueryServiceTest.java
@@ -56,7 +56,7 @@ class QueryServiceTest extends BaseTest {
         .status(QueryDetails.StatusEnum.SUCCESS)
         .totalRecords(2));
       when(queryClient.getSortedIds(fqlQueryId, 0, Integer.MAX_VALUE))
-        .thenReturn(Collections.singletonList(List.of(UUID.randomUUID(), UUID.randomUUID())));
+        .thenReturn(Collections.singletonList(List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString())));
 
       queryService.checkQueryExecutionStatus(operation);
 


### PR DESCRIPTION
[MODBULKOPS-279](https://folio-org.atlassian.net/browse/MODBULKOPS-279) - FQM flow: tenant information populating

## Purpose
To verify if request for central tenant returns: 
- identifiers of instances associated with the central tenant
- identifiers of  holdings records from member tenant
- identifiers of items from member tenants
- identifiers of user records from central tenant. 

## Approach


### TODOS and Open Questions


## Learning


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
