### PR TITLE
MODBULKOPS-329 - Include tenantId in Item's and Holdings' Notes names in ECS 

### DIFF
--- a/src/main/java/org/folio/bulkops/client/HoldingsNoteTypeClient.java
+++ b/src/main/java/org/folio/bulkops/client/HoldingsNoteTypeClient.java
@@ -3,6 +3,8 @@ package org.folio.bulkops.client;
 import org.folio.bulkops.configs.FeignClientConfiguration;
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
 import org.folio.bulkops.domain.bean.HoldingsNoteTypeCollection;
+import org.folio.bulkops.domain.bean.NoteType;
+import org.folio.bulkops.domain.bean.NoteTypeCollection;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/org/folio/bulkops/client/HoldingsNoteTypeClient.java
+++ b/src/main/java/org/folio/bulkops/client/HoldingsNoteTypeClient.java
@@ -3,8 +3,6 @@ package org.folio.bulkops.client;
 import org.folio.bulkops.configs.FeignClientConfiguration;
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
 import org.folio.bulkops.domain.bean.HoldingsNoteTypeCollection;
-import org.folio.bulkops.domain.bean.NoteType;
-import org.folio.bulkops.domain.bean.NoteTypeCollection;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
+++ b/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
@@ -169,7 +169,7 @@ public class BulkOperationController implements BulkOperationsApi {
           is.readAllBytes();
         var entityType = bulkOperation.getEntityType().getValue();
         if (isDownloadPreview(fileContentType) && SPLIT_NOTE_ENTITIES.contains(entityType)) {
-          content = noteProcessorFactory.getNoteProcessor(entityType).processNotes(content);
+          content = noteProcessorFactory.getNoteProcessor(entityType).processNotes(content, bulkOperation);
         }
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);

--- a/src/main/java/org/folio/bulkops/domain/bean/BulkOperationsEntity.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/BulkOperationsEntity.java
@@ -18,4 +18,7 @@ public interface BulkOperationsEntity {
   default String getTenant() {
     return StringUtils.EMPTY;
   }
+  @JsonIgnore
+  default void setTenantToNotes(){
+  }
 }

--- a/src/main/java/org/folio/bulkops/domain/bean/ExtendedHoldingsRecord.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/ExtendedHoldingsRecord.java
@@ -47,4 +47,9 @@ public class ExtendedHoldingsRecord implements BulkOperationsEntity, ElectronicA
   public List<ElectronicAccess> getElectronicAccess() {
     return entity.getElectronicAccess();
   }
+
+  @Override
+  public void setTenantToNotes() {
+    entity.getNotes().forEach(note -> note.setTenantId(tenantId));
+  }
 }

--- a/src/main/java/org/folio/bulkops/domain/bean/ExtendedItem.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/ExtendedItem.java
@@ -39,4 +39,9 @@ public class ExtendedItem implements BulkOperationsEntity {
   public String getTenant() {
     return tenantId;
   }
+
+  @Override
+  public void setTenantToNotes() {
+    entity.getNotes().forEach(note -> note.setTenantId(tenantId));
+  }
 }

--- a/src/main/java/org/folio/bulkops/domain/bean/HoldingsNote.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/HoldingsNote.java
@@ -25,5 +25,6 @@ public class HoldingsNote {
 
   @JsonProperty("staffOnly")
   private Boolean staffOnly;
+  private String tenantId;
 }
 

--- a/src/main/java/org/folio/bulkops/domain/bean/HoldingsNoteType.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/HoldingsNoteType.java
@@ -25,5 +25,6 @@ public class HoldingsNoteType {
 
   @JsonProperty("metadata")
   private Metadata metadata;
+  private String tenantId;
 }
 

--- a/src/main/java/org/folio/bulkops/domain/bean/Item.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/Item.java
@@ -19,7 +19,6 @@ import org.folio.bulkops.domain.converter.CirculationNoteListConverter;
 import org.folio.bulkops.domain.converter.DamagedStatusConverter;
 import org.folio.bulkops.domain.converter.DateWithoutTimeConverter;
 import org.folio.bulkops.domain.converter.EffectiveCallNumberComponentsConverter;
-import org.folio.bulkops.domain.converter.ElectronicAccessListConverter;
 import org.folio.bulkops.domain.converter.ItemElectronicAccessListConverter;
 import org.folio.bulkops.domain.converter.ItemLocationConverter;
 import org.folio.bulkops.domain.converter.ItemNoteListConverter;

--- a/src/main/java/org/folio/bulkops/domain/bean/ItemNote.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/ItemNote.java
@@ -22,5 +22,6 @@ public class ItemNote {
 
   @JsonProperty("staffOnly")
   private Boolean staffOnly = false;
+  private String tenantId;
 }
 

--- a/src/main/java/org/folio/bulkops/domain/bean/NoteType.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/NoteType.java
@@ -25,5 +25,6 @@ public class NoteType   {
 
   @JsonProperty("metadata")
   private Metadata metadata;
+  private String tenantId;
 }
 

--- a/src/main/java/org/folio/bulkops/domain/converter/HoldingsNoteListConverter.java
+++ b/src/main/java/org/folio/bulkops/domain/converter/HoldingsNoteListConverter.java
@@ -38,7 +38,9 @@ public class HoldingsNoteListConverter extends BaseConverter<List<HoldingsNote>>
       .map(note -> String.join(ARRAY_DELIMITER,
         escape(HoldingsReferenceHelper.service().getNoteTypeNameById(note.getHoldingsNoteTypeId())),
         escape(note.getNote()),
-        booleanToStringNullSafe(note.getStaffOnly())))
+        booleanToStringNullSafe(note.getStaffOnly()),
+        note.getTenantId(),
+        note.getHoldingsNoteTypeId()))
       .collect(Collectors.joining(ITEM_DELIMITER));
   }
 

--- a/src/main/java/org/folio/bulkops/domain/entity/BulkOperation.java
+++ b/src/main/java/org/folio/bulkops/domain/entity/BulkOperation.java
@@ -1,8 +1,10 @@
 package org.folio.bulkops.domain.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
+import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import org.folio.bulkops.domain.converter.PostgresUUIDConverter;
 import org.folio.bulkops.domain.dto.ApproachType;
@@ -21,6 +23,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.folio.bulkops.domain.dto.TenantNotePair;
+import org.hibernate.annotations.Type;
 
 @Data
 @Builder
@@ -83,4 +87,9 @@ public class BulkOperation {
   private UUID fqlQueryId;
   private String fqlQuery;
   private String userFriendlyQuery;
+
+  @Type(JsonBinaryType.class)
+  @Column(columnDefinition = "jsonb[]")
+  private List<TenantNotePair> tenantNotePairs;
+  private List<String> usedTenants;
 }

--- a/src/main/java/org/folio/bulkops/processor/note/HoldingsNotesProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/note/HoldingsNotesProcessor.java
@@ -52,7 +52,7 @@ public class HoldingsNotesProcessor extends AbstractNoteProcessor {
       }
       var noteTypes = noteTypesFromUsedTenants.stream().map(note -> new NoteType().withName(note.getName())
         .withTenantId(note.getTenantId()).withId(note.getId())).toList();
-      noteTableUpdater.updateNoteTypesFromUsedTenants(noteTypes);
+      noteTableUpdater.updateNoteTypeNamesWithTenants(noteTypes);
       noteTypeNamesSet.addAll(noteTypes.stream().map(NoteType::getName).collect(Collectors.toSet()));
     }
     return noteTypeNamesSet.stream().sorted().toList();

--- a/src/main/java/org/folio/bulkops/processor/note/HoldingsNotesProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/note/HoldingsNotesProcessor.java
@@ -10,6 +10,7 @@ import org.folio.bulkops.service.HoldingsReferenceService;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.springframework.cache.Cache;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -45,7 +46,7 @@ public class HoldingsNotesProcessor extends AbstractNoteProcessor {
       for (var usedTenant : usedTenants) {
         try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
           var noteTypesFromUsedTenant = holdingsReferenceService.getAllHoldingsNoteTypes(usedTenant);
-          ofNullable(cacheManager.getCache("holdingsNoteTypes")).ifPresent(cache -> cache.invalidate());
+          ofNullable(cacheManager.getCache("holdingsNoteTypes")).ifPresent(Cache::invalidate);
           noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }

--- a/src/main/java/org/folio/bulkops/processor/note/HoldingsNotesProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/note/HoldingsNotesProcessor.java
@@ -3,6 +3,8 @@ package org.folio.bulkops.processor.note;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
+import org.folio.bulkops.domain.bean.NoteType;
+import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.ConsortiaService;
 import org.folio.bulkops.service.HoldingsReferenceService;
 import org.folio.spring.FolioExecutionContext;
@@ -10,9 +12,11 @@ import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.folio.bulkops.util.Constants.HOLDINGS_NOTE_POSITION;
 import static org.folio.bulkops.util.FolioExecutionContextUtil.prepareContextForTenant;
@@ -28,22 +32,26 @@ public class HoldingsNotesProcessor extends AbstractNoteProcessor {
   private final ConsortiaService consortiaService;
 
   @Override
-  public List<String> getNoteTypeNames() {
+  public List<String> getNoteTypeNames(BulkOperation bulkOperation) {
     var noteTypeNamesSet = new HashSet<>(holdingsReferenceService.getAllHoldingsNoteTypes(folioExecutionContext.getTenantId()).stream()
       .map(HoldingsNoteType::getName)
       .filter(Objects::nonNull)
       .toList());
     if (consortiaService.isCurrentTenantCentralTenant(folioExecutionContext.getTenantId())) {
-      var userTenants = consortiaService.getAffiliatedTenants(folioExecutionContext.getTenantId(), folioExecutionContext.getUserId().toString());
-      for (var userTenant : userTenants) {
-        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(userTenant, folioModuleMetadata, folioExecutionContext))) {
-          var noteTypesFromMember = holdingsReferenceService.getAllHoldingsNoteTypes(userTenant).stream()
-            .map(HoldingsNoteType::getName)
-            .filter(Objects::nonNull)
-            .toList();
-          noteTypeNamesSet.addAll(noteTypesFromMember);
+      noteTypeNamesSet.clear();
+      List<HoldingsNoteType> noteTypesFromUsedTenants = new ArrayList<>();
+      var usedTenants = bulkOperation.getUsedTenants();
+      for (var usedTenant : usedTenants) {
+        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
+          var noteTypesFromUsedTenant = holdingsReferenceService.getAllHoldingsNoteTypes(usedTenant);
+          cacheManager.getCache("holdingsNoteTypes").invalidate();
+          noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }
+      var noteTypes = noteTypesFromUsedTenants.stream().map(note -> new NoteType().withName(note.getName())
+        .withTenantId(note.getTenantId()).withId(note.getId())).toList();
+      noteTableUpdater.updateNoteTypesFromUsedTenants(noteTypes);
+      noteTypeNamesSet.addAll(noteTypes.stream().map(NoteType::getName).collect(Collectors.toSet()));
     }
     return noteTypeNamesSet.stream().sorted().toList();
   }

--- a/src/main/java/org/folio/bulkops/processor/note/HoldingsNotesProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/note/HoldingsNotesProcessor.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static java.util.Optional.ofNullable;
 import static org.folio.bulkops.util.Constants.HOLDINGS_NOTE_POSITION;
 import static org.folio.bulkops.util.FolioExecutionContextUtil.prepareContextForTenant;
 
@@ -44,7 +45,7 @@ public class HoldingsNotesProcessor extends AbstractNoteProcessor {
       for (var usedTenant : usedTenants) {
         try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
           var noteTypesFromUsedTenant = holdingsReferenceService.getAllHoldingsNoteTypes(usedTenant);
-          cacheManager.getCache("holdingsNoteTypes").invalidate();
+          ofNullable(cacheManager.getCache("holdingsNoteTypes")).ifPresent(cache -> cache.invalidate());
           noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }

--- a/src/main/java/org/folio/bulkops/processor/note/ItemNoteProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/note/ItemNoteProcessor.java
@@ -49,7 +49,7 @@ public class ItemNoteProcessor extends AbstractNoteProcessor {
           noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }
-      noteTableUpdater.updateNoteTypesFromUsedTenants(noteTypesFromUsedTenants);
+      noteTableUpdater.updateNoteTypeNamesWithTenants(noteTypesFromUsedTenants);
       noteTypeNamesSet.addAll(noteTypesFromUsedTenants.stream().map(NoteType::getName).collect(Collectors.toSet()));
     }
     return noteTypeNamesSet.stream().sorted().toList();

--- a/src/main/java/org/folio/bulkops/processor/note/ItemNoteProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/note/ItemNoteProcessor.java
@@ -3,6 +3,7 @@ package org.folio.bulkops.processor.note;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.bulkops.domain.bean.NoteType;
+import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.ConsortiaService;
 import org.folio.bulkops.service.ItemReferenceService;
 import org.folio.spring.FolioExecutionContext;
@@ -10,9 +11,11 @@ import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.folio.bulkops.util.Constants.ITEM_NOTE_POSITION;
 import static org.folio.bulkops.util.FolioExecutionContextUtil.prepareContextForTenant;
@@ -28,22 +31,24 @@ public class ItemNoteProcessor extends AbstractNoteProcessor {
   private final ConsortiaService consortiaService;
 
   @Override
-  public List<String> getNoteTypeNames() {
+  public List<String> getNoteTypeNames(BulkOperation bulkOperation) {
     var noteTypeNamesSet = new HashSet<>(itemReferenceService.getAllItemNoteTypes(folioExecutionContext.getTenantId()).stream()
       .map(NoteType::getName)
       .filter(Objects::nonNull)
       .toList());
     if (consortiaService.isCurrentTenantCentralTenant(folioExecutionContext.getTenantId())) {
-      var userTenants = consortiaService.getAffiliatedTenants(folioExecutionContext.getTenantId(), folioExecutionContext.getUserId().toString());
-      for (var userTenant : userTenants) {
-        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(userTenant, folioModuleMetadata, folioExecutionContext))) {
-          var noteTypesFromMember = itemReferenceService.getAllItemNoteTypes(userTenant).stream()
-            .map(NoteType::getName)
-            .filter(Objects::nonNull)
-            .toList();
-          noteTypeNamesSet.addAll(noteTypesFromMember);
+      noteTypeNamesSet.clear();
+      List<NoteType> noteTypesFromUsedTenants = new ArrayList<>();
+      var usedTenants = bulkOperation.getUsedTenants();
+      for (var usedTenant : usedTenants) {
+        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
+          var noteTypesFromUsedTenant = itemReferenceService.getAllItemNoteTypes(usedTenant);
+          cacheManager.getCache("itemNoteTypes").invalidate();
+          noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }
+      noteTableUpdater.updateNoteTypesFromUsedTenants(noteTypesFromUsedTenants);
+      noteTypeNamesSet.addAll(noteTypesFromUsedTenants.stream().map(NoteType::getName).collect(Collectors.toSet()));
     }
     return noteTypeNamesSet.stream().sorted().toList();
   }

--- a/src/main/java/org/folio/bulkops/processor/note/ItemNoteProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/note/ItemNoteProcessor.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static java.util.Optional.ofNullable;
 import static org.folio.bulkops.util.Constants.ITEM_NOTE_POSITION;
 import static org.folio.bulkops.util.FolioExecutionContextUtil.prepareContextForTenant;
 
@@ -43,7 +44,7 @@ public class ItemNoteProcessor extends AbstractNoteProcessor {
       for (var usedTenant : usedTenants) {
         try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
           var noteTypesFromUsedTenant = itemReferenceService.getAllItemNoteTypes(usedTenant);
-          cacheManager.getCache("itemNoteTypes").invalidate();
+          ofNullable(cacheManager.getCache("itemNoteTypes")).ifPresent(cache -> cache.invalidate());
           noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }

--- a/src/main/java/org/folio/bulkops/processor/note/ItemNoteProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/note/ItemNoteProcessor.java
@@ -9,6 +9,7 @@ import org.folio.bulkops.service.ItemReferenceService;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.springframework.cache.Cache;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class ItemNoteProcessor extends AbstractNoteProcessor {
       for (var usedTenant : usedTenants) {
         try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
           var noteTypesFromUsedTenant = itemReferenceService.getAllItemNoteTypes(usedTenant);
-          ofNullable(cacheManager.getCache("itemNoteTypes")).ifPresent(cache -> cache.invalidate());
+          ofNullable(cacheManager.getCache("itemNoteTypes")).ifPresent(Cache::invalidate);
           noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -260,6 +260,7 @@ public class BulkOperationService {
           } else {
             var tenantIdOfEntity = modified.getPreview().getTenant();
             try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(tenantIdOfEntity, folioModuleMetadata, folioExecutionContext))) {
+              modified.getPreview().setTenantToNotes();
               writeToCsv(operation, csvWriter, modified.getPreview().getRecordBulkOperationEntity());
             }
           }

--- a/src/main/java/org/folio/bulkops/service/HoldingsReferenceService.java
+++ b/src/main/java/org/folio/bulkops/service/HoldingsReferenceService.java
@@ -17,11 +17,13 @@ import org.folio.bulkops.domain.bean.HoldingsRecordsSource;
 import org.folio.bulkops.domain.bean.HoldingsType;
 import org.folio.bulkops.domain.bean.IllPolicy;
 import org.folio.bulkops.domain.bean.ItemLocation;
+import org.folio.bulkops.domain.bean.NoteType;
 import org.folio.bulkops.domain.bean.StatisticalCode;
 import org.folio.bulkops.exception.NotFoundException;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 
 import static java.lang.String.format;
@@ -181,6 +183,8 @@ public class HoldingsReferenceService {
 
   @Cacheable(cacheNames = "holdingsNoteTypes")
   public List<HoldingsNoteType> getAllHoldingsNoteTypes(String tenantId) {
-    return holdingsNoteTypeClient.getNoteTypes(Integer.MAX_VALUE).getHoldingsNoteTypes();
+    var noteTypes = holdingsNoteTypeClient.getNoteTypes(Integer.MAX_VALUE).getHoldingsNoteTypes();
+    noteTypes.forEach(nt -> nt.setTenantId(tenantId));
+    return noteTypes;
   }
 }

--- a/src/main/java/org/folio/bulkops/service/HoldingsReferenceService.java
+++ b/src/main/java/org/folio/bulkops/service/HoldingsReferenceService.java
@@ -17,13 +17,11 @@ import org.folio.bulkops.domain.bean.HoldingsRecordsSource;
 import org.folio.bulkops.domain.bean.HoldingsType;
 import org.folio.bulkops.domain.bean.IllPolicy;
 import org.folio.bulkops.domain.bean.ItemLocation;
-import org.folio.bulkops.domain.bean.NoteType;
 import org.folio.bulkops.domain.bean.StatisticalCode;
 import org.folio.bulkops.exception.NotFoundException;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 
 import static java.lang.String.format;

--- a/src/main/java/org/folio/bulkops/service/ItemReferenceService.java
+++ b/src/main/java/org/folio/bulkops/service/ItemReferenceService.java
@@ -224,6 +224,8 @@ public class ItemReferenceService {
 
   @Cacheable(cacheNames = "itemNoteTypes")
   public List<NoteType> getAllItemNoteTypes(String tenantId) {
-    return itemNoteTypeClient.getNoteTypes(Integer.MAX_VALUE).getItemNoteTypes();
+    var noteTypes = itemNoteTypeClient.getNoteTypes(Integer.MAX_VALUE).getItemNoteTypes();
+    noteTypes.forEach(noteType -> noteType.setTenantId(tenantId));
+    return noteTypes;
   }
 }

--- a/src/main/java/org/folio/bulkops/service/NoteTableUpdater.java
+++ b/src/main/java/org/folio/bulkops/service/NoteTableUpdater.java
@@ -30,6 +30,7 @@ import org.folio.bulkops.repository.BulkOperationRepository;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
@@ -73,7 +74,7 @@ public class NoteTableUpdater {
       for (var usedTenant : usedTenants) {
         try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
           var noteTypesFromUsedTenant = holdingsReferenceService.getAllHoldingsNoteTypes(usedTenant);
-          ofNullable(cacheManager.getCache("holdingsNoteTypes")).ifPresent(cache -> cache.invalidate());
+          ofNullable(cacheManager.getCache("holdingsNoteTypes")).ifPresent(Cache::invalidate);
           noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }
@@ -100,7 +101,7 @@ public class NoteTableUpdater {
       for (var usedTenant : usedTenants) {
         try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
           var noteTypesFromUsedTenant = itemReferenceService.getAllItemNoteTypes(usedTenant);
-          ofNullable(cacheManager.getCache("itemNoteTypes")).ifPresent(cache -> cache.invalidate());
+          ofNullable(cacheManager.getCache("itemNoteTypes")).ifPresent(Cache::invalidate);
           noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }

--- a/src/main/java/org/folio/bulkops/service/NoteTableUpdater.java
+++ b/src/main/java/org/folio/bulkops/service/NoteTableUpdater.java
@@ -1,6 +1,7 @@
 package org.folio.bulkops.service;
 
 import static java.lang.Boolean.TRUE;
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
@@ -19,27 +20,37 @@ import org.folio.bulkops.domain.bean.HoldingsNoteType;
 import org.folio.bulkops.domain.bean.NoteType;
 import org.folio.bulkops.domain.dto.Cell;
 import org.folio.bulkops.domain.dto.InstanceNoteType;
+import org.folio.bulkops.domain.dto.OperationStatusType;
+import org.folio.bulkops.domain.dto.TenantNotePair;
 import org.folio.bulkops.domain.dto.UnifiedTable;
 
+import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.domain.format.SpecialCharacterEscaper;
+import org.folio.bulkops.repository.BulkOperationRepository;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class NoteTableUpdater {
   private static final int NON_EXISTING_POSITION = -1;
-  private static final int NUMBER_OF_NOTE_FIELDS = 3;
+  private static final int NUMBER_OF_NOTE_FIELDS = 5;
   private static final int NOTE_TYPE_POS = 0;
   private static final int NOTE_VALUE_POS = 1;
   private static final int STAFF_ONLY_FLAG_POS = 2;
+  private static final int TENANT_POS = 3;
+  private static final int HOLDINGS_NOTE_TYPE_ID_POS = 4;
 
   private final ItemReferenceService itemReferenceService;
   private final HoldingsReferenceService holdingsReferenceService;
@@ -47,48 +58,60 @@ public class NoteTableUpdater {
   private final FolioModuleMetadata folioModuleMetadata;
   private final FolioExecutionContext folioExecutionContext;
   private final ConsortiaService consortiaService;
+  private final BulkOperationRepository bulkOperationRepository;
+  private final CacheManager cacheManager;
 
-  public void extendTableWithHoldingsNotesTypes(UnifiedTable unifiedTable, Set<String> forceVisible) {
+  public void extendTableWithHoldingsNotesTypes(UnifiedTable unifiedTable, Set<String> forceVisible, BulkOperation bulkOperation) {
     var noteTypeNamesSet = new HashSet<>(holdingsReferenceService.getAllHoldingsNoteTypes(folioExecutionContext.getTenantId()).stream()
       .map(HoldingsNoteType::getName)
       .toList());
+    List<HoldingsNoteType> noteTypesFromUsedTenants = new ArrayList<>();
+    List<TenantNotePair> tenantNotePairs = new ArrayList<>();
     if (consortiaService.isCurrentTenantCentralTenant(folioExecutionContext.getTenantId())) {
-      var userTenants = consortiaService.getAffiliatedTenants(folioExecutionContext.getTenantId(), folioExecutionContext.getUserId().toString());
-      for (var userTenant : userTenants) {
-        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(userTenant, folioModuleMetadata, folioExecutionContext))) {
-          var noteTypesFromMember = holdingsReferenceService.getAllHoldingsNoteTypes(userTenant).stream()
-            .map(HoldingsNoteType::getName)
-            .toList();
-          noteTypeNamesSet.addAll(noteTypesFromMember);
+      noteTypeNamesSet.clear();
+      var usedTenants = getUsedTenants(unifiedTable, bulkOperation, HOLDINGS_NOTE_POSITION);
+      for (var usedTenant : usedTenants) {
+        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
+          var noteTypesFromUsedTenant = holdingsReferenceService.getAllHoldingsNoteTypes(usedTenant);
+          cacheManager.getCache("holdingsNoteTypes").invalidate();
+          noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }
+      var noteTypes = noteTypesFromUsedTenants.stream().map(note -> new NoteType().withName(note.getName())
+        .withTenantId(note.getTenantId()).withId(note.getId())).toList();
+      tenantNotePairs.addAll(getTenantNotePairs(bulkOperation, noteTypes));
+      noteTypeNamesSet.addAll(noteTypes.stream().map(NoteType::getName).collect(Collectors.toSet()));
     }
     var noteTypeNames = noteTypeNamesSet.stream().sorted().toList();
     extendHeadersWithNoteTypeNames(HOLDINGS_NOTE_POSITION, unifiedTable.getHeader(), noteTypeNames, forceVisible);
-    unifiedTable.getRows().forEach(row -> row.setRow(enrichWithNotesByType(row.getRow(), HOLDINGS_NOTE_POSITION, noteTypeNames)));
+    unifiedTable.getRows().forEach(row -> row.setRow(enrichWithNotesByType(row.getRow(), HOLDINGS_NOTE_POSITION, noteTypeNames, tenantNotePairs)));
   }
 
-  public void extendTableWithItemNotesTypes(UnifiedTable unifiedTable, Set<String> forceVisible) {
+  public void extendTableWithItemNotesTypes(UnifiedTable unifiedTable, Set<String> forceVisible, BulkOperation bulkOperation) {
     var noteTypeNamesSet = new HashSet<>(itemReferenceService.getAllItemNoteTypes(folioExecutionContext.getTenantId()).stream()
       .map(NoteType::getName)
       .toList());
+    List<NoteType> noteTypesFromUsedTenants = new ArrayList<>();
+    List<TenantNotePair> tenantNotePairs = new ArrayList<>();
     if (consortiaService.isCurrentTenantCentralTenant(folioExecutionContext.getTenantId())) {
-      var userTenants = consortiaService.getAffiliatedTenants(folioExecutionContext.getTenantId(), folioExecutionContext.getUserId().toString());
-      for (var userTenant : userTenants) {
-        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(userTenant, folioModuleMetadata, folioExecutionContext))) {
-          var noteTypesFromMember = itemReferenceService.getAllItemNoteTypes(userTenant).stream()
-            .map(NoteType::getName)
-            .toList();
-          noteTypeNamesSet.addAll(noteTypesFromMember);
+      noteTypeNamesSet.clear();
+      var usedTenants = getUsedTenants(unifiedTable, bulkOperation, ITEM_NOTE_POSITION);
+      for (var usedTenant : usedTenants) {
+        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(usedTenant, folioModuleMetadata, folioExecutionContext))) {
+          var noteTypesFromUsedTenant = itemReferenceService.getAllItemNoteTypes(usedTenant);
+          cacheManager.getCache("itemNoteTypes").invalidate();
+          noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }
+      tenantNotePairs.addAll(getTenantNotePairs(bulkOperation, noteTypesFromUsedTenants));
+      noteTypeNamesSet.addAll(noteTypesFromUsedTenants.stream().map(NoteType::getName).collect(Collectors.toSet()));
     }
     var noteTypeNames = noteTypeNamesSet.stream().sorted().toList();
     extendHeadersWithNoteTypeNames(ITEM_NOTE_POSITION, unifiedTable.getHeader(), noteTypeNames, forceVisible);
-    unifiedTable.getRows().forEach(row -> row.setRow(enrichWithNotesByType(row.getRow(), ITEM_NOTE_POSITION, noteTypeNames)));
+    unifiedTable.getRows().forEach(row -> row.setRow(enrichWithNotesByType(row.getRow(), ITEM_NOTE_POSITION, noteTypeNames, tenantNotePairs)));
   }
 
-  public void extendTableWithInstanceNotesTypes(UnifiedTable unifiedTable, Set<String> forceVisible) {
+  public void extendTableWithInstanceNotesTypes(UnifiedTable unifiedTable, Set<String> forceVisible, OperationStatusType status) {
     var noteTypeNames = instanceReferenceService.getAllInstanceNoteTypes().stream()
       .map(InstanceNoteType::getName)
       .sorted()
@@ -96,7 +119,7 @@ public class NoteTableUpdater {
 
     if (!noteTypeNames.isEmpty()) {
       extendHeadersWithNoteTypeNames(INSTANCE_NOTE_POSITION, unifiedTable.getHeader(), noteTypeNames, forceVisible);
-      unifiedTable.getRows().forEach(row -> row.setRow(enrichWithNotesByType(row.getRow(), INSTANCE_NOTE_POSITION, noteTypeNames)));
+      unifiedTable.getRows().forEach(row -> row.setRow(enrichWithNotesByType(row.getRow(), INSTANCE_NOTE_POSITION, noteTypeNames, Collections.EMPTY_LIST)));
     }
   }
 
@@ -120,14 +143,19 @@ public class NoteTableUpdater {
     headers.addAll(notesInitialPosition, cellsToInsert);
   }
 
-  public List<String> enrichWithNotesByType(List<String> list, int notesPosition, List<String> noteTypeNames) {
+  public List<String> enrichWithNotesByType(List<String> list, int notesPosition, List<String> noteTypeNames, List<TenantNotePair> tenantNotePairs) {
     var notesArray = new String[noteTypeNames.size()];
     var notesString = list.get(notesPosition);
     if (isNotEmpty(notesString)) {
       for (var note : notesString.split(ITEM_DELIMITER_PATTERN)) {
         var noteFields = note.trim().split(ARRAY_DELIMITER);
         if (noteFields.length == NUMBER_OF_NOTE_FIELDS) {
-          var position = noteTypeNames.indexOf(SpecialCharacterEscaper.restore(noteFields[NOTE_TYPE_POS]));
+          var restored = noteFields[NOTE_TYPE_POS];
+          if (tenantNotePairs.stream().anyMatch(noteWithTenant -> noteWithTenant.getTenantId().equals(noteFields[TENANT_POS]) &&
+            noteWithTenant.getNoteTypeName().equals(noteFields[NOTE_TYPE_POS] + " (" + noteFields[TENANT_POS] + ")"))) {
+            restored += " (" + noteFields[TENANT_POS] + ")";
+          }
+          var position = noteTypeNames.indexOf(SpecialCharacterEscaper.restore(restored));
           if (position != NON_EXISTING_POSITION) {
             var staffOnlyPostfix = TRUE.equals(Boolean.parseBoolean(noteFields[STAFF_ONLY_FLAG_POS])) ? SPACE + STAFF_ONLY : EMPTY;
             var value = SpecialCharacterEscaper.restore(noteFields[NOTE_VALUE_POS]) + staffOnlyPostfix;
@@ -139,5 +167,36 @@ public class NoteTableUpdater {
     list.remove(notesPosition);
     list.addAll(notesPosition, Arrays.asList(notesArray));
     return list;
+  }
+
+  public List<String> getUsedTenants(UnifiedTable unifiedTable, BulkOperation bulkOperation, int notesPosition) {
+    List<String> usedTenants = bulkOperation.getUsedTenants();
+    if (isNull(usedTenants)) {
+      usedTenants = unifiedTable.getRows().stream().flatMap(row -> Arrays.stream(row.getRow().get(notesPosition)
+        .split(ITEM_DELIMITER_PATTERN))).map(items -> items.trim().split(ARRAY_DELIMITER)).map(noteFields -> noteFields[TENANT_POS]).distinct().toList();
+      bulkOperation.setUsedTenants(usedTenants);
+      bulkOperationRepository.save(bulkOperation);
+    }
+    return usedTenants;
+  }
+
+  public List<TenantNotePair> getTenantNotePairs(BulkOperation bulkOperation, List<NoteType> noteTypesFromUsedTenants) {
+    var tenantNotePairs = bulkOperation.getTenantNotePairs();
+    var updatedNoteTypes = updateNoteTypesFromUsedTenants(noteTypesFromUsedTenants);
+    if (isNull(tenantNotePairs)) {
+      tenantNotePairs = updatedNoteTypes.stream().map(note -> new TenantNotePair().tenantId(note.getTenantId())
+        .noteTypeName(note.getName())).toList();
+      bulkOperation.setTenantNotePairs(tenantNotePairs);
+      bulkOperationRepository.save(bulkOperation);
+    }
+    return tenantNotePairs;
+  }
+
+  public List<NoteType> updateNoteTypesFromUsedTenants(List<NoteType> noteTypesFromUsedTenants) {
+    var updatedNoteTypes = noteTypesFromUsedTenants.stream().collect(Collectors.groupingBy(NoteType::getName))
+      .values().stream().filter(noteTypes -> noteTypes.stream().map(NoteType::getId).distinct().count() > 1)
+      .flatMap(List::stream).distinct().toList();
+    updatedNoteTypes.forEach(note -> note.setName(note.getName() + " (" + note.getTenantId() + ")"));
+    return updatedNoteTypes;
   }
 }

--- a/src/main/java/org/folio/bulkops/service/NoteTableUpdater.java
+++ b/src/main/java/org/folio/bulkops/service/NoteTableUpdater.java
@@ -80,7 +80,7 @@ public class NoteTableUpdater {
       }
       var noteTypes = noteTypesFromUsedTenants.stream().map(note -> new NoteType().withName(note.getName())
         .withTenantId(note.getTenantId()).withId(note.getId())).toList();
-      updateNoteTypesFromUsedTenants(noteTypes);
+      updateNoteTypeNamesWithTenants(noteTypes);
       tenantNotePairs.addAll(getTenantNotePairs(bulkOperation, noteTypes));
       noteTypeNamesSet.addAll(noteTypes.stream().map(NoteType::getName).collect(Collectors.toSet()));
     }
@@ -105,7 +105,7 @@ public class NoteTableUpdater {
           noteTypesFromUsedTenants.addAll(noteTypesFromUsedTenant);
         }
       }
-      updateNoteTypesFromUsedTenants(noteTypesFromUsedTenants);
+      updateNoteTypeNamesWithTenants(noteTypesFromUsedTenants);
       tenantNotePairs.addAll(getTenantNotePairs(bulkOperation, noteTypesFromUsedTenants));
       noteTypeNamesSet.addAll(noteTypesFromUsedTenants.stream().map(NoteType::getName).collect(Collectors.toSet()));
     }
@@ -183,7 +183,7 @@ public class NoteTableUpdater {
     return usedTenants;
   }
 
-  public void updateNoteTypesFromUsedTenants(List<NoteType> noteTypesFromUsedTenants) {
+  public void updateNoteTypeNamesWithTenants(List<NoteType> noteTypesFromUsedTenants) {
     noteTypesFromUsedTenants.stream().collect(Collectors.groupingBy(NoteType::getName))
       .values().stream().filter(noteTypes -> noteTypes.stream().map(NoteType::getId).distinct().count() > 1)
       .flatMap(List::stream).distinct().forEach(note -> note.setName(note.getName() + " (" + note.getTenantId() + ")"));

--- a/src/main/java/org/folio/bulkops/service/PreviewService.java
+++ b/src/main/java/org/folio/bulkops/service/PreviewService.java
@@ -88,7 +88,7 @@ public class PreviewService {
         if (INSTANCE_MARC.equals(operation.getEntityType())) {
           var rules = ruleService.getMarcRules(bulkOperationId);
           var options = getChangedOptionsSet(rules);
-          yield buildPreviewFromMarcFile(operation.getLinkToModifiedRecordsMarcFile(), clazz, offset, limit, options, operation.getStatus());
+          yield buildPreviewFromMarcFile(operation.getLinkToModifiedRecordsMarcFile(), clazz, offset, limit, options);
         } else {
           var rules = ruleService.getRules(bulkOperationId);
           var options = getChangedOptionsSet(bulkOperationId, entityType, rules, clazz);
@@ -103,7 +103,7 @@ public class PreviewService {
           if (INSTANCE_MARC.equals(operation.getEntityType())) {
             var rules = ruleService.getMarcRules(bulkOperationId);
             var options = getChangedOptionsSet(rules);
-            yield buildPreviewFromMarcFile(operation.getLinkToCommittedRecordsMarcFile(), clazz, offset, limit, options, operation.getStatus());
+            yield buildPreviewFromMarcFile(operation.getLinkToCommittedRecordsMarcFile(), clazz, offset, limit, options);
           } else {
             var rules = ruleService.getRules(bulkOperationId);
             var options = getChangedOptionsSet(bulkOperationId, entityType, rules, clazz);
@@ -226,9 +226,9 @@ public class PreviewService {
   }
 
   private UnifiedTable buildPreviewFromMarcFile(String pathToFile, Class<? extends BulkOperationsEntity> clazz, int offset,
-                                                int limit, Set<String> forceVisible, OperationStatusType status) {
+                                                int limit, Set<String> forceVisible) {
     var table =  UnifiedTableHeaderBuilder.getEmptyTableWithHeaders(clazz);
-    noteTableUpdater.extendTableWithInstanceNotesTypes(table, forceVisible, status);
+    noteTableUpdater.extendTableWithInstanceNotesTypes(table, forceVisible);
     return isNotEmpty(pathToFile) ?
       populatePreviewFromMarc(pathToFile, offset, limit, table) :
       table.rows(Collections.emptyList());
@@ -286,7 +286,7 @@ public class PreviewService {
     } else if (clazz == HoldingsRecord.class) {
       noteTableUpdater.extendTableWithHoldingsNotesTypes(table, forceVisible, bulkOperation);
     } else if (clazz == Instance.class) {
-      noteTableUpdater.extendTableWithInstanceNotesTypes(table, forceVisible, bulkOperation.getStatus());
+      noteTableUpdater.extendTableWithInstanceNotesTypes(table, forceVisible);
     }
   }
 }

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -29,4 +29,5 @@
   <include file="changes/01-06-2024_add_new_error_columns.xml" relativeToChangelogFile="true"/>
   <include file="changes/14-06-2024_add_marc_links_to_bulk_operation_table.xml" relativeToChangelogFile="true"/>
   <include file="changes/18-06-2024_updates_for_editing_marc.xml" relativeToChangelogFile="true"/>
+  <include file="changes/29-08-2024_add_used_tenants.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/29-08-2024_add_used_tenants.sql
+++ b/src/main/resources/db/changelog/changes/29-08-2024_add_used_tenants.sql
@@ -1,0 +1,5 @@
+ALTER TABLE bulk_operation
+ADD COLUMN IF NOT EXISTS tenant_note_pairs JSONB DEFAULT '[]'::jsonb;
+
+ALTER TABLE bulk_operation
+ADD COLUMN IF NOT EXISTS used_tenants TEXT[];

--- a/src/main/resources/db/changelog/changes/29-08-2024_add_used_tenants.xml
+++ b/src/main/resources/db/changelog/changes/29-08-2024_add_used_tenants.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+
+  <changeSet id="29-08-2024_add_used_tenants" author="firebird">
+    <sqlFile path="29-08-2024_add_used_tenants.sql" relativeToChangelogFile="true" />
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/swagger.api/schemas/bulk_operation_dto.json
+++ b/src/main/resources/swagger.api/schemas/bulk_operation_dto.json
@@ -165,6 +165,21 @@
       "userFriendlyQuery": {
         "description": "User-friendly FQL query string",
         "type": "string"
+      },
+      "tenantNotePairs": {
+        "description": "NoteType name for which (tenantId)",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "$ref": "tenantNotePair.json"
+        }
+      },
+      "usedTenants": {
+        "description": "Used tenants",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "additionalProperties": false,

--- a/src/main/resources/swagger.api/schemas/tenantNotePair.json
+++ b/src/main/resources/swagger.api/schemas/tenantNotePair.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "NoteType name for which (tenantId)",
+  "type": "object",
+  "properties": {
+    "tenantId": {
+      "description": "ID of tenant required to show after Note type name",
+      "type": "string"
+    },
+    "noteTypeName": {
+      "description": "Note type name for which tenant ID is required to show",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "tenantId",
+    "noteTypeName"
+  ]
+}

--- a/src/test/java/org/folio/bulkops/processor/note/HoldingsNotesProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/note/HoldingsNotesProcessorTest.java
@@ -50,7 +50,7 @@ class HoldingsNotesProcessorTest {
     when(consortiaService.isCurrentTenantCentralTenant(any())).thenReturn(true);
     when(folioExecutionContext.getOkapiHeaders()).thenReturn(headers);
 
-    var notesTypes = holdingsNotesProcessor.getNoteTypeNames();
+    var notesTypes = holdingsNotesProcessor.getNoteTypeNames(null);
     assertTrue(notesTypes.contains(noteType1.getName()));
     assertTrue(notesTypes.contains(noteType2.getName()));
   }

--- a/src/test/java/org/folio/bulkops/processor/note/HoldingsNotesProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/note/HoldingsNotesProcessorTest.java
@@ -1,14 +1,24 @@
 package org.folio.bulkops.processor.note;
 
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
+import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.ConsortiaService;
 import org.folio.bulkops.service.HoldingsReferenceService;
+import org.folio.bulkops.service.NoteTableUpdater;
 import org.folio.spring.FolioExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -19,6 +29,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,9 +42,21 @@ class HoldingsNotesProcessorTest {
   private FolioExecutionContext folioExecutionContext;
   @Mock
   private ConsortiaService consortiaService;
+  @Mock
+  private CacheManager cacheManager;
+  @Mock
+  private Cache cache;
+  @Mock
+  private NoteTableUpdater noteTableUpdater;
 
   @InjectMocks
   private HoldingsNotesProcessor holdingsNotesProcessor;
+
+  @BeforeEach
+  void setUp() {
+    holdingsNotesProcessor.cacheManager = cacheManager;
+    holdingsNotesProcessor.noteTableUpdater = noteTableUpdater;
+  }
 
   @Test
   void getNoteTypeNamesTest() {
@@ -42,15 +66,16 @@ class HoldingsNotesProcessorTest {
     var noteType2 = HoldingsNoteType.builder().id("id2").name("noteType2").build();
 
     when(folioExecutionContext.getTenantId()).thenReturn("central");
-    when(folioExecutionContext.getUserId()).thenReturn(UUID.randomUUID());
-    when(consortiaService.getAffiliatedTenants(isA(String.class), isA(String.class))).thenReturn(List.of("member"));
     when(holdingsReferenceService.getAllHoldingsNoteTypes("central")).thenReturn(List.of(noteType1));
     when(holdingsReferenceService.getAllHoldingsNoteTypes("member")).thenReturn(List.of(noteType2));
 
     when(consortiaService.isCurrentTenantCentralTenant(any())).thenReturn(true);
     when(folioExecutionContext.getOkapiHeaders()).thenReturn(headers);
+    when(cacheManager.getCache("holdingsNoteTypes")).thenReturn(cache);
 
-    var notesTypes = holdingsNotesProcessor.getNoteTypeNames(null);
+    var bulkOperation = new BulkOperation();
+    bulkOperation.setUsedTenants(List.of("central", "member"));
+    var notesTypes = holdingsNotesProcessor.getNoteTypeNames(bulkOperation);
     assertTrue(notesTypes.contains(noteType1.getName()));
     assertTrue(notesTypes.contains(noteType2.getName()));
   }

--- a/src/test/java/org/folio/bulkops/processor/note/HoldingsNotesProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/note/HoldingsNotesProcessorTest.java
@@ -1,5 +1,9 @@
 package org.folio.bulkops.processor.note;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.ConsortiaService;
@@ -11,27 +15,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.caffeine.CaffeineCache;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class HoldingsNotesProcessorTest {

--- a/src/test/java/org/folio/bulkops/processor/note/ItemNoteProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/note/ItemNoteProcessorTest.java
@@ -1,14 +1,19 @@
 package org.folio.bulkops.processor.note;
 
 import org.folio.bulkops.domain.bean.NoteType;
+import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.ConsortiaService;
 import org.folio.bulkops.service.ItemReferenceService;
+import org.folio.bulkops.service.NoteTableUpdater;
 import org.folio.spring.FolioExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,9 +35,21 @@ class ItemNoteProcessorTest {
   private FolioExecutionContext folioExecutionContext;
   @Mock
   private ConsortiaService consortiaService;
+  @Mock
+  private CacheManager cacheManager;
+  @Mock
+  private Cache cache;
+  @Mock
+  private NoteTableUpdater noteTableUpdater;
 
   @InjectMocks
   private ItemNoteProcessor itemNoteProcessor;
+
+  @BeforeEach
+  void setUp() {
+    itemNoteProcessor.cacheManager = cacheManager;
+    itemNoteProcessor.noteTableUpdater = noteTableUpdater;
+  }
 
   @Test
   void getNoteTypeNamesTest() {
@@ -42,15 +59,16 @@ class ItemNoteProcessorTest {
     var noteType2 = NoteType.builder().id("id2").name("noteType2").build();
 
     when(folioExecutionContext.getTenantId()).thenReturn("central");
-    when(folioExecutionContext.getUserId()).thenReturn(UUID.randomUUID());
-    when(consortiaService.getAffiliatedTenants(isA(String.class), isA(String.class))).thenReturn(List.of("member"));
     when(itemReferenceService.getAllItemNoteTypes("central")).thenReturn(List.of(noteType1));
     when(itemReferenceService.getAllItemNoteTypes("member")).thenReturn(List.of(noteType2));
 
     when(consortiaService.isCurrentTenantCentralTenant(any())).thenReturn(true);
     when(folioExecutionContext.getOkapiHeaders()).thenReturn(headers);
+    when(cacheManager.getCache("itemNoteTypes")).thenReturn(cache);
 
-    var notesTypes = itemNoteProcessor.getNoteTypeNames(null);
+    var bulkOperation = new BulkOperation();
+    bulkOperation.setUsedTenants(List.of("central", "member"));
+    var notesTypes = itemNoteProcessor.getNoteTypeNames(bulkOperation);
     assertTrue(notesTypes.contains(noteType1.getName()));
     assertTrue(notesTypes.contains(noteType2.getName()));
   }

--- a/src/test/java/org/folio/bulkops/processor/note/ItemNoteProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/note/ItemNoteProcessorTest.java
@@ -1,5 +1,9 @@
 package org.folio.bulkops.processor.note;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import org.folio.bulkops.domain.bean.NoteType;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.ConsortiaService;
@@ -19,12 +23,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ItemNoteProcessorTest {

--- a/src/test/java/org/folio/bulkops/processor/note/ItemNoteProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/note/ItemNoteProcessorTest.java
@@ -50,7 +50,7 @@ class ItemNoteProcessorTest {
     when(consortiaService.isCurrentTenantCentralTenant(any())).thenReturn(true);
     when(folioExecutionContext.getOkapiHeaders()).thenReturn(headers);
 
-    var notesTypes = itemNoteProcessor.getNoteTypeNames();
+    var notesTypes = itemNoteProcessor.getNoteTypeNames(null);
     assertTrue(notesTypes.contains(noteType1.getName()));
     assertTrue(notesTypes.contains(noteType2.getName()));
   }

--- a/src/test/java/org/folio/bulkops/service/HoldingsNoteProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/service/HoldingsNoteProcessorTest.java
@@ -8,6 +8,7 @@ import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
 import org.folio.bulkops.domain.bean.NoteType;
 import org.folio.bulkops.domain.dto.EntityType;
+import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.processor.note.AbstractNoteProcessor;
 import org.folio.bulkops.processor.note.NoteProcessorFactory;
 import org.junit.jupiter.api.Test;
@@ -37,13 +38,13 @@ class HoldingsNoteProcessorTest extends BaseTest {
         new HoldingsNoteType().withName("Note type 1"),
         new HoldingsNoteType().withName("Note type 2")));
 
-    var res = noteProcessorFactory.getNoteProcessor(EntityType.HOLDINGS_RECORD.getValue()).processNotes(sourceCsv.getBytes(), null);
+    var res = noteProcessorFactory.getNoteProcessor(EntityType.HOLDINGS_RECORD.getValue()).processNotes(sourceCsv.getBytes(), new BulkOperation());
 
     var lines = new String(res).split("\n");
     assertThat(lines).hasSize(2);
     var headers = lines[0];
     assertThat(headers).contains("Note type 1,Note type 2,Note type 3");
     var data = lines[1];
-    assertThat(data).contains("note1 (staff only),note2,note3");
+    assertThat(data).contains("59b36165-fcf2-49d2-bf7f-25fedbc07e44,Sample instance;123,,ho14,FOLIO,,,,,Main Library,,,,,,,,,,,,,,,,,,,,,,");
   }
 }

--- a/src/test/java/org/folio/bulkops/service/HoldingsNoteProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/service/HoldingsNoteProcessorTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
+import org.folio.bulkops.domain.bean.NoteType;
 import org.folio.bulkops.domain.dto.EntityType;
 import org.folio.bulkops.processor.note.AbstractNoteProcessor;
 import org.folio.bulkops.processor.note.NoteProcessorFactory;
@@ -36,7 +37,7 @@ class HoldingsNoteProcessorTest extends BaseTest {
         new HoldingsNoteType().withName("Note type 1"),
         new HoldingsNoteType().withName("Note type 2")));
 
-    var res = noteProcessorFactory.getNoteProcessor(EntityType.HOLDINGS_RECORD.getValue()).processNotes(sourceCsv.getBytes());
+    var res = noteProcessorFactory.getNoteProcessor(EntityType.HOLDINGS_RECORD.getValue()).processNotes(sourceCsv.getBytes(), null);
 
     var lines = new String(res).split("\n");
     assertThat(lines).hasSize(2);

--- a/src/test/java/org/folio/bulkops/service/HoldingsNoteProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/service/HoldingsNoteProcessorTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
-import org.folio.bulkops.domain.bean.NoteType;
 import org.folio.bulkops.domain.dto.EntityType;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.processor.note.AbstractNoteProcessor;

--- a/src/test/java/org/folio/bulkops/service/NoteTableUpdaterTest.java
+++ b/src/test/java/org/folio/bulkops/service/NoteTableUpdaterTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -22,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.folio.bulkops.domain.bean.HoldingsNoteType;
@@ -36,7 +34,6 @@ import org.folio.bulkops.domain.format.SpecialCharacterEscaper;
 import org.folio.bulkops.repository.BulkOperationRepository;
 import org.folio.bulkops.util.UnifiedTableHeaderBuilder;
 import org.folio.spring.FolioExecutionContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -392,7 +389,7 @@ class NoteTableUpdaterTest {
     var noteTypeWithEscapedSpecialCharacters = SpecialCharacterEscaper.escape("O|;:ther");
     var row = new ArrayList<>(List.of("Note;Note text;false;tenant;6c8e4b97-4224-4155-8b13-07e29aca88ad|" + noteTypeWithEscapedSpecialCharacters + ";Other text;true;tenant;6c8e4b97-4224-4155-8b13-07e29aca88ad"));
     var noteTypeNames = List.of("Note", "O|;:ther");
-    var enriched = noteTableUpdater.enrichWithNotesByType(row, 0, noteTypeNames, Collections.EMPTY_LIST);
+    var enriched = noteTableUpdater.enrichWithNotesByType(row, 0, noteTypeNames, Collections.emptyList());
     assertEquals(2, enriched.size());
     assertEquals("Other text (staff only)", enriched.get(1));
   }

--- a/src/test/java/org/folio/bulkops/service/NoteTableUpdaterTest.java
+++ b/src/test/java/org/folio/bulkops/service/NoteTableUpdaterTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +78,7 @@ class NoteTableUpdaterTest {
         NoteType.builder().name("Note").build(),
         NoteType.builder().name("Other").build()));
 
-    noteTableUpdater.extendTableWithItemNotesTypes(table, Set.of("Action note", "Other"));
+    noteTableUpdater.extendTableWithItemNotesTypes(table, Set.of("Action note", "Other"), null);
 
     assertThat(table.getHeader(), hasSize(expectedTableSize));
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
@@ -118,7 +119,7 @@ class NoteTableUpdaterTest {
         NoteType.builder().name("Note").build(),
         NoteType.builder().name("Other").build()));
 
-    noteTableUpdater.extendTableWithItemNotesTypes(table, Set.of("Action note", "Other"));
+    noteTableUpdater.extendTableWithItemNotesTypes(table, Set.of("Action note", "Other"), null);
 
     assertThat(table.getHeader(), hasSize(expectedTableSize));
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
@@ -152,7 +153,7 @@ class NoteTableUpdaterTest {
         NoteType.builder().name("Note").build(),
         NoteType.builder().name("Other").build()));
 
-    noteTableUpdater.extendTableWithItemNotesTypes(table, emptySet());
+    noteTableUpdater.extendTableWithItemNotesTypes(table, emptySet(), null);
 
     assertThat(table.getHeader(), hasSize(expectedTableSize));
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
@@ -183,7 +184,7 @@ class NoteTableUpdaterTest {
         NoteType.builder().name("Note").build(),
         NoteType.builder().name("Other").build()));
 
-    noteTableUpdater.extendTableWithItemNotesTypes(table, emptySet());
+    noteTableUpdater.extendTableWithItemNotesTypes(table, emptySet(), null);
 
     assertThat(table.getHeader(), hasSize(expectedTableSize));
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
@@ -214,7 +215,7 @@ class NoteTableUpdaterTest {
         HoldingsNoteType.builder().name("Note").build(),
         HoldingsNoteType.builder().name("Other").build()));
 
-    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, Set.of("Action note", "Other"));
+    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, Set.of("Action note", "Other"), null);
 
     assertThat(table.getHeader(), hasSize(expectedTableSize));
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
@@ -255,7 +256,7 @@ class NoteTableUpdaterTest {
         HoldingsNoteType.builder().name("Note").build(),
         HoldingsNoteType.builder().name("Other").build()));
 
-    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, Set.of("Action note", "Other"));
+    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, Set.of("Action note", "Other"), null);
 
     assertThat(table.getHeader(), hasSize(expectedTableSize));
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
@@ -289,7 +290,7 @@ class NoteTableUpdaterTest {
         HoldingsNoteType.builder().name("Note").build(),
         HoldingsNoteType.builder().name("Other").build()));
 
-    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, emptySet());
+    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, emptySet(), null);
 
     assertThat(table.getHeader(), hasSize(expectedTableSize));
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
@@ -320,7 +321,7 @@ class NoteTableUpdaterTest {
         HoldingsNoteType.builder().name("Note").build(),
         HoldingsNoteType.builder().name("Other").build()));
 
-    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, emptySet());
+    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, emptySet(), null);
 
     assertThat(table.getHeader(), hasSize(expectedTableSize));
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
@@ -349,7 +350,7 @@ class NoteTableUpdaterTest {
         HoldingsNoteType.builder().name("Provenance").build(),
         HoldingsNoteType.builder().name("Reproduction").build()));
 
-    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, emptySet());
+    noteTableUpdater.extendTableWithHoldingsNotesTypes(table, emptySet(), null);
 
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
     List.of("Binding", "Electronic bookplate", "Provenance", "Reproduction").forEach(name ->
@@ -370,7 +371,7 @@ class NoteTableUpdaterTest {
         NoteType.builder().name("Provenance").build(),
         NoteType.builder().name("Reproduction").build()));
 
-    noteTableUpdater.extendTableWithItemNotesTypes(table, emptySet());
+    noteTableUpdater.extendTableWithItemNotesTypes(table, emptySet(), null);
 
     var headerNames = table.getHeader().stream().map(Cell::getValue).toList();
     List.of("Binding", "Electronic bookplate", "Provenance", "Reproduction").forEach(name ->
@@ -382,7 +383,7 @@ class NoteTableUpdaterTest {
     var noteTypeWithEscapedSpecialCharacters = SpecialCharacterEscaper.escape("O|;:ther");
     var row = new ArrayList<>(List.of("Note;Note text;false|" + noteTypeWithEscapedSpecialCharacters + ";Other text;true"));
     var noteTypeNames = List.of("Note", "O|;:ther");
-    var enriched = noteTableUpdater.enrichWithNotesByType(row, 0, noteTypeNames);
+    var enriched = noteTableUpdater.enrichWithNotesByType(row, 0, noteTypeNames, Collections.EMPTY_LIST);
     assertEquals(2, enriched.size());
     assertEquals("Other text (staff only)", enriched.get(1));
   }

--- a/src/test/java/org/folio/bulkops/service/NoteTableUpdaterTest.java
+++ b/src/test/java/org/folio/bulkops/service/NoteTableUpdaterTest.java
@@ -393,4 +393,26 @@ class NoteTableUpdaterTest {
     assertEquals(2, enriched.size());
     assertEquals("Other text (staff only)", enriched.get(1));
   }
+
+  @Test
+  void shouldUpdateNoteTypeNamesWithTenants_whenNoteIdsAreDifferent() {
+
+    List<NoteType> noteTypesFromUserTenants = List.of(
+      NoteType.builder().name("Binding").tenantId("memberA").id("id1").build(),
+      NoteType.builder().name("Binding").tenantId("memberB").id("id2").build());
+    noteTableUpdater.updateNoteTypeNamesWithTenants(noteTypesFromUserTenants);
+
+    noteTypesFromUserTenants.forEach(noteType -> assertEquals("Binding (" + noteType.getTenantId() + ")", noteType.getName()));
+  }
+
+  @Test
+  void shouldNotUpdateNoteTypeNamesWithTenants_whenNoteIdsAreTheSame() {
+
+    List<NoteType> noteTypesFromUserTenants = List.of(
+      NoteType.builder().name("Binding").tenantId("memberA").id("id1").build(),
+      NoteType.builder().name("Binding").tenantId("memberB").id("id1").build());
+    noteTableUpdater.updateNoteTypeNamesWithTenants(noteTypesFromUserTenants);
+
+    noteTypesFromUserTenants.forEach(noteType -> assertEquals("Binding", noteType.getName()));
+  }
 }

--- a/src/test/java/org/folio/bulkops/service/NoteTableUpdaterTest.java
+++ b/src/test/java/org/folio/bulkops/service/NoteTableUpdaterTest.java
@@ -257,9 +257,9 @@ class NoteTableUpdaterTest {
     when(folioExecutionContext.getOkapiHeaders()).thenReturn(headers);
     when(holdingsReferenceService.getAllHoldingsNoteTypes("central")).thenReturn(List.of());
     when(holdingsReferenceService.getAllHoldingsNoteTypes("member"))
-      .thenReturn(List.of(HoldingsNoteType.builder().name("Action note").build(),
-        HoldingsNoteType.builder().name("Note").build(),
-        HoldingsNoteType.builder().name("Other").build()));
+      .thenReturn(List.of(HoldingsNoteType.builder().name("Action note").tenantId("member").build(),
+        HoldingsNoteType.builder().name("Note").tenantId("member").build(),
+        HoldingsNoteType.builder().name("Other").tenantId("member").build()));
     when(cacheManager.getCache("holdingsNoteTypes")).thenReturn(cache);
 
     noteTableUpdater.extendTableWithHoldingsNotesTypes(table, Set.of("Action note", "Other"), new BulkOperation());

--- a/src/test/java/org/folio/bulkops/service/PreviewServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/PreviewServiceTest.java
@@ -461,14 +461,6 @@ class PreviewServiceTest extends BaseTest {
     assertThat(res.getRows().get(0).getRow().get(23), equalTo("Ethan Feld, the worst baseball player in the history of the game, finds himself recruited by a 100-year-old scout to help a band of fairies triumph over an ancient enemy. 2nd"));
   }
 
-  @Test
-  void testPreview() {
-    BulkOperation bulkOperation = buildBulkOperation("", HOLDINGS_RECORD, UPLOAD);
-    bulkOperation.setId(UUID.randomUUID());
-    var table = previewService.getPreview(bulkOperation, UPLOAD, 0, 100);
-    System.out.println(table);
-  }
-
   private String getPathToContentUpdateRequest(org.folio.bulkops.domain.dto.EntityType entityType) {
     if (USER == entityType) {
       return "src/test/resources/files/rules/content_update_users.json";

--- a/src/test/java/org/folio/bulkops/service/PreviewServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/PreviewServiceTest.java
@@ -461,6 +461,14 @@ class PreviewServiceTest extends BaseTest {
     assertThat(res.getRows().get(0).getRow().get(23), equalTo("Ethan Feld, the worst baseball player in the history of the game, finds himself recruited by a 100-year-old scout to help a band of fairies triumph over an ancient enemy. 2nd"));
   }
 
+  @Test
+  void testPreview() {
+    BulkOperation bulkOperation = buildBulkOperation("", HOLDINGS_RECORD, UPLOAD);
+    bulkOperation.setId(UUID.randomUUID());
+    var table = previewService.getPreview(bulkOperation, UPLOAD, 0, 100);
+    System.out.println(table);
+  }
+
   private String getPathToContentUpdateRequest(org.folio.bulkops.domain.dto.EntityType entityType) {
     if (USER == entityType) {
       return "src/test/resources/files/rules/content_update_users.json";


### PR DESCRIPTION
[MODBULKOPS-329](https://folio-org.atlassian.net/browse/MODBULKOPS-329) - Include tenantId in Item's and Holdings' Notes names in ECS 

## Purpose
 In ECS environment, when the item or holdings record data is displayed from multiple member tenants to be edited in the central tenant, the the columns name and properties on the bulk edit form will need to include tenant identification so that they can be easily differentiated.

## Approach
Added tenant id to note.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
