### PR TITLE
MODBULKOPS-334 - Preventing record update with values from different tenants 

### DIFF
--- a/src/main/java/org/folio/bulkops/domain/entity/BulkOperationRuleDetails.java
+++ b/src/main/java/org/folio/bulkops/domain/entity/BulkOperationRuleDetails.java
@@ -45,4 +45,6 @@ public class BulkOperationRuleDetails {
   @Type(JsonBinaryType.class)
   @Column(columnDefinition = "jsonb")
   private List<Parameter> parameters;
+
+  private List<String> tenants;
 }

--- a/src/main/java/org/folio/bulkops/exception/RuleValidationTenantsException.java
+++ b/src/main/java/org/folio/bulkops/exception/RuleValidationTenantsException.java
@@ -1,0 +1,7 @@
+package org.folio.bulkops.exception;
+
+public class RuleValidationTenantsException extends Exception {
+  public RuleValidationTenantsException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
@@ -8,6 +8,7 @@ import org.folio.bulkops.domain.dto.BulkOperationRule;
 import org.folio.bulkops.domain.dto.BulkOperationRuleCollection;
 import org.folio.bulkops.domain.dto.UpdateOptionType;
 import org.folio.bulkops.exception.RuleValidationException;
+import org.folio.bulkops.exception.RuleValidationTenantsException;
 import org.folio.bulkops.service.ConsortiaService;
 import org.folio.bulkops.service.ErrorService;
 import org.folio.spring.FolioExecutionContext;
@@ -18,8 +19,6 @@ import org.springframework.stereotype.Component;
 
 import lombok.extern.log4j.Log4j2;
 
-import static java.util.Objects.nonNull;
-import static org.folio.bulkops.util.Constants.RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE;
 import static org.folio.bulkops.util.FolioExecutionContextUtil.prepareContextForTenant;
 
 @Log4j2
@@ -42,31 +41,18 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
     for (BulkOperationRule rule : rules.getBulkOperationRules()) {
       var details = rule.getRuleDetails();
       var option = details.getOption();
-      var tenantsFromRule = rule.getRuleDetails().getTenants();
-      if (nonNull(tenantsFromRule) && !tenantsFromRule.isEmpty() && !tenantsFromRule.contains(entity.getTenant())) {
-        var errorMsg = String.format(RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE, entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue());
-        try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(consortiaService.getCentralTenantId(folioExecutionContext.getTenantId()), folioModuleMetadata, folioExecutionContext))) {
-          errorService.saveError(rule.getBulkOperationId(), identifier, errorMsg);
-        }
-        log.error(errorMsg);
-        continue;
-      }
       for (Action action : details.getActions()) {
-        var tenantsFromAction = action.getTenants();
-        if (nonNull(tenantsFromAction) && !tenantsFromAction.isEmpty() && !tenantsFromAction.contains(entity.getTenant())) {
-          var errorMsg = String.format(RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE, entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue());
-          try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(consortiaService.getCentralTenantId(folioExecutionContext.getTenantId()), folioModuleMetadata, folioExecutionContext))) {
-            errorService.saveError(rule.getBulkOperationId(), identifier, errorMsg);
-          }
-          log.error(errorMsg);
-          continue;
-        }
         try {
           updater(option, action).apply(preview);
-          validator(entity).validate(option, action);
+          validator(entity).validate(option, action, rule);
           updater(option, action).apply(updated);
         } catch (RuleValidationException e) {
           errorService.saveError(rule.getBulkOperationId(), identifier, e.getMessage());
+        } catch (RuleValidationTenantsException e) {
+          try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(consortiaService.getCentralTenantId(folioExecutionContext.getTenantId()), folioModuleMetadata, folioExecutionContext))) {
+            errorService.saveError(rule.getBulkOperationId(), identifier, e.getMessage());
+          }
+          log.error(e.getMessage());
         } catch (Exception e) {
           log.error(String.format("%s id=%s, error: %s", updated.getRecordBulkOperationEntity().getClass().getSimpleName(), "id", e.getMessage()));
           errorService.saveError(rule.getBulkOperationId(), identifier, e.getMessage());
@@ -84,7 +70,7 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
    * @param entity entity of type {@link T} to validate
    * @return true if {@link UpdateOptionType} and {@link Action} can be applied to entity
    */
-  public abstract Validator<UpdateOptionType, Action> validator(T entity);
+  public abstract Validator<UpdateOptionType, Action, BulkOperationRule> validator(T entity);
 
   /**
    * Returns {@link Consumer<T>} for applying changes for entity of type {@link T}

--- a/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
@@ -52,6 +52,7 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
         }
         log.error(String.format("%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.",
           entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
+        continue;
       }
       for (Action action : details.getActions()) {
         var tenantsFromAction = action.getTenants();
@@ -66,6 +67,7 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
           }
           log.error(String.format("%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.",
             entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
+          continue;
         }
         try {
           updater(option, action).apply(preview);

--- a/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
@@ -27,12 +27,10 @@ import static org.folio.bulkops.util.FolioExecutionContextUtil.prepareContextFor
 public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> implements DataProcessor<T> {
   @Autowired
   private ErrorService errorService;
-  @Autowired
-  protected FolioExecutionContext folioExecutionContext;
-  @Autowired
   private FolioModuleMetadata folioModuleMetadata;
-  @Autowired
   private ConsortiaService consortiaService;
+
+  protected FolioExecutionContext folioExecutionContext;
 
   @Override
   public UpdatedEntityHolder process(String identifier, T entity, BulkOperationRuleCollection rules) {
@@ -111,4 +109,19 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
    * @return true if objects are equal, otherwise - false
    */
   public abstract boolean compare(T first, T second);
+
+  @Autowired
+  public void setFolioExecutionContext(FolioExecutionContext folioExecutionContext) {
+    this.folioExecutionContext = folioExecutionContext;
+  }
+
+  @Autowired
+  public void setFolioModuleMetadata(FolioModuleMetadata folioModuleMetadata) {
+    this.folioModuleMetadata = folioModuleMetadata;
+  }
+
+  @Autowired
+  public void setConsortiaService(ConsortiaService consortiaService) {
+    this.consortiaService = consortiaService;
+  }
 }

--- a/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
@@ -8,16 +8,13 @@ import org.folio.bulkops.domain.dto.BulkOperationRule;
 import org.folio.bulkops.domain.dto.BulkOperationRuleCollection;
 import org.folio.bulkops.domain.dto.UpdateOptionType;
 import org.folio.bulkops.exception.RuleValidationException;
-import org.folio.bulkops.service.ConsortiaService;
 import org.folio.bulkops.service.ErrorService;
-import org.folio.spring.FolioExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import lombok.extern.log4j.Log4j2;
 
 import static java.util.Objects.nonNull;
-import static java.util.Optional.ofNullable;
 
 @Log4j2
 @Component
@@ -34,17 +31,25 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
       var details = rule.getRuleDetails();
       var option = details.getOption();
       var tenantsFromRule = rule.getRuleDetails().getTenants();
+      log.info("tenantsFromRule: {}, entity.tenant: {}, entity.identifier: {}",
+        tenantsFromRule, entity.getTenant(), entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID));
       if (nonNull(tenantsFromRule) && !tenantsFromRule.isEmpty() && !tenantsFromRule.contains(entity.getTenant())) {
         errorService.saveError(rule.getBulkOperationId(), identifier,
           String.format("%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.",
             entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
+        log.error(String.format("%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.",
+          entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
       }
       for (Action action : details.getActions()) {
         var tenantsFromAction = action.getTenants();
+        log.info("tenantsFromAction: {}, entity.tenant: {}, entity.identifier: {}",
+          tenantsFromAction, entity.getTenant(), entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID));
         if (nonNull(tenantsFromAction) && !tenantsFromAction.isEmpty() && !tenantsFromAction.contains(entity.getTenant())) {
           errorService.saveError(rule.getBulkOperationId(), identifier,
             String.format("%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.",
               entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
+          log.error(String.format("%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.",
+            entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
         }
         try {
           updater(option, action).apply(preview);

--- a/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
@@ -43,9 +43,9 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
       var option = details.getOption();
       for (Action action : details.getActions()) {
         try {
-          updater(option, action).apply(preview);
+          updater(option, action, entity, rule).apply(preview);
           validator(entity).validate(option, action, rule);
-          updater(option, action).apply(updated);
+          updater(option, action, entity, rule).apply(updated);
         } catch (RuleValidationException e) {
           errorService.saveError(rule.getBulkOperationId(), identifier, e.getMessage());
         } catch (RuleValidationTenantsException e) {
@@ -69,7 +69,7 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
    * Returns validator
    *
    * @param entity entity of type {@link T} to validate
-   * @return true if {@link UpdateOptionType} and {@link Action} can be applied to entity
+   * @return true if {@link UpdateOptionType} and {@link Action}, and {@link BulkOperationRule} can be applied to entity
    */
   public abstract Validator<UpdateOptionType, Action, BulkOperationRule> validator(T entity);
 
@@ -78,9 +78,11 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
    *
    * @param option {@link UpdateOptionType} for update
    * @param action {@link Action} for update
+   * @param action {@link T} for update
+   * @param action {@link BulkOperationRule} for update
    * @return updater
    */
-  public abstract Updater<T> updater(UpdateOptionType option, Action action);
+  public abstract Updater<T> updater(UpdateOptionType option, Action action, T entity, BulkOperationRule rule) throws RuleValidationTenantsException;
 
   /**
    * Clones object of type {@link T}

--- a/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
@@ -16,15 +16,14 @@ import org.springframework.stereotype.Component;
 
 import lombok.extern.log4j.Log4j2;
 
+import static java.util.Objects.nonNull;
+import static java.util.Optional.ofNullable;
+
 @Log4j2
 @Component
 public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> implements DataProcessor<T> {
   @Autowired
   private ErrorService errorService;
-  @Autowired
-  private ConsortiaService consortiaService;
-  @Autowired
-  private FolioExecutionContext folioExecutionContext;
 
   @Override
   public UpdatedEntityHolder process(String identifier, T entity, BulkOperationRuleCollection rules) {
@@ -35,14 +34,14 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
       var details = rule.getRuleDetails();
       var option = details.getOption();
       var tenantsFromRule = rule.getRuleDetails().getTenants();
-      if (consortiaService.isCurrentTenantCentralTenant(folioExecutionContext.getTenantId()) && !tenantsFromRule.isEmpty() && !tenantsFromRule.contains(entity.getTenant())) {
+      if (nonNull(tenantsFromRule) && !tenantsFromRule.isEmpty() && !tenantsFromRule.contains(entity.getTenant())) {
         errorService.saveError(rule.getBulkOperationId(), identifier,
           String.format("%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.",
             entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
       }
       for (Action action : details.getActions()) {
         var tenantsFromAction = action.getTenants();
-        if (consortiaService.isCurrentTenantCentralTenant(folioExecutionContext.getTenantId()) && !tenantsFromAction.isEmpty() && !tenantsFromAction.contains(entity.getTenant())) {
+        if (nonNull(tenantsFromAction) && !tenantsFromAction.isEmpty() && !tenantsFromAction.contains(entity.getTenant())) {
           errorService.saveError(rule.getBulkOperationId(), identifier,
             String.format("%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.",
               entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));

--- a/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
@@ -50,6 +50,7 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
           errorService.saveError(rule.getBulkOperationId(), identifier, e.getMessage());
         } catch (RuleValidationTenantsException e) {
           try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(consortiaService.getCentralTenantId(folioExecutionContext.getTenantId()), folioModuleMetadata, folioExecutionContext))) {
+            log.info("current tenant: {}", folioExecutionContext.getTenantId());
             errorService.saveError(rule.getBulkOperationId(), identifier, e.getMessage());
           }
           log.error(e.getMessage());

--- a/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/AbstractDataProcessor.java
@@ -27,9 +27,11 @@ import static org.folio.bulkops.util.FolioExecutionContextUtil.prepareContextFor
 public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> implements DataProcessor<T> {
   @Autowired
   private ErrorService errorService;
+  @Autowired
   private FolioModuleMetadata folioModuleMetadata;
+  @Autowired
   private ConsortiaService consortiaService;
-
+  @Autowired
   protected FolioExecutionContext folioExecutionContext;
 
   @Override
@@ -109,19 +111,4 @@ public abstract class AbstractDataProcessor<T extends BulkOperationsEntity> impl
    * @return true if objects are equal, otherwise - false
    */
   public abstract boolean compare(T first, T second);
-
-  @Autowired
-  public void setFolioExecutionContext(FolioExecutionContext folioExecutionContext) {
-    this.folioExecutionContext = folioExecutionContext;
-  }
-
-  @Autowired
-  public void setFolioModuleMetadata(FolioModuleMetadata folioModuleMetadata) {
-    this.folioModuleMetadata = folioModuleMetadata;
-  }
-
-  @Autowired
-  public void setConsortiaService(ConsortiaService consortiaService) {
-    this.consortiaService = consortiaService;
-  }
 }

--- a/src/main/java/org/folio/bulkops/processor/FolioInstanceDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/FolioInstanceDataProcessor.java
@@ -46,7 +46,7 @@ public class FolioInstanceDataProcessor extends AbstractDataProcessor<ExtendedIn
   }
 
   @Override
-  public Updater<ExtendedInstance> updater(UpdateOptionType option, Action action) {
+  public Updater<ExtendedInstance> updater(UpdateOptionType option, Action action, ExtendedInstance entity, BulkOperationRule rule) {
     if (STAFF_SUPPRESS.equals(option)) {
       if (SET_TO_TRUE.equals(action.getType())) {
         return extendedInstance -> extendedInstance.getEntity().setStaffSuppress(true);

--- a/src/main/java/org/folio/bulkops/processor/FolioInstanceDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/FolioInstanceDataProcessor.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.bulkops.domain.bean.ExtendedInstance;
 import org.folio.bulkops.domain.dto.Action;
 import org.folio.bulkops.domain.dto.UpdateOptionType;
+import org.folio.bulkops.domain.dto.BulkOperationRule;
 import org.folio.bulkops.exception.BulkOperationException;
 import org.folio.bulkops.exception.RuleValidationException;
 import org.springframework.stereotype.Component;
@@ -32,8 +33,8 @@ public class FolioInstanceDataProcessor extends AbstractDataProcessor<ExtendedIn
   private final InstanceNotesUpdaterFactory instanceNotesUpdaterFactory;
 
   @Override
-  public Validator<UpdateOptionType, Action> validator(ExtendedInstance extendedInstance) {
-    return (option, action) -> {
+  public Validator<UpdateOptionType, Action, BulkOperationRule> validator(ExtendedInstance extendedInstance) {
+    return (option, action, rule) -> {
       if (CLEAR_FIELD.equals(action.getType()) && Set.of(STAFF_SUPPRESS, SUPPRESS_FROM_DISCOVERY).contains(option)) {
         throw new RuleValidationException("Suppress flag cannot be cleared.");
       } else if (INSTANCE_NOTE.equals(option) && !"FOLIO".equals(extendedInstance.getEntity().getSource())) {

--- a/src/main/java/org/folio/bulkops/processor/HoldingsDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/HoldingsDataProcessor.java
@@ -72,13 +72,14 @@ public class HoldingsDataProcessor extends AbstractDataProcessor<ExtendedHolding
       }
       if (PERMANENT_LOCATION == option && CLEAR_FIELD == action.getType()) {
         throw new RuleValidationException("Permanent location cannot be cleared");
-      } else if (ruleTenantsAreNotValid(rule, action, extendedHoldingsRecord)) {
-        throw new RuleValidationTenantsException(String.format(RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE, extendedHoldingsRecord.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), extendedHoldingsRecord.getTenant(), option.getValue()));
       }
     };
   }
 
-  public Updater<ExtendedHoldingsRecord> updater(UpdateOptionType option, Action action) {
+  public Updater<ExtendedHoldingsRecord> updater(UpdateOptionType option, Action action, ExtendedHoldingsRecord entity, BulkOperationRule rule) throws RuleValidationTenantsException {
+    if (ruleTenantsAreNotValid(rule, action, entity)) {
+      throw new RuleValidationTenantsException(String.format(RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE, entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
+    }
     if (isElectronicAccessUpdate(option)) {
       return (Updater<ExtendedHoldingsRecord>) electronicAccessUpdaterFactory.updater(option, action);
     } else if (REPLACE_WITH == action.getType()) {

--- a/src/main/java/org/folio/bulkops/processor/HoldingsDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/HoldingsDataProcessor.java
@@ -72,9 +72,7 @@ public class HoldingsDataProcessor extends AbstractDataProcessor<ExtendedHolding
       }
       if (PERMANENT_LOCATION == option && CLEAR_FIELD == action.getType()) {
         throw new RuleValidationException("Permanent location cannot be cleared");
-      } else if (nonNull(rule.getRuleDetails().getTenants()) && !rule.getRuleDetails().getTenants().isEmpty() && !rule.getRuleDetails().getTenants().contains(extendedHoldingsRecord.getTenant())
-        ||
-        nonNull(action.getTenants()) && !action.getTenants().isEmpty() && !action.getTenants().contains(extendedHoldingsRecord.getTenant())) {
+      } else if (ruleTenantsAreNotValid(rule, action, extendedHoldingsRecord)) {
         throw new RuleValidationTenantsException(String.format(RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE, extendedHoldingsRecord.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), extendedHoldingsRecord.getTenant(), option.getValue()));
       }
     };
@@ -186,5 +184,12 @@ public class HoldingsDataProcessor extends AbstractDataProcessor<ExtendedHolding
   @Override
   public Class<ExtendedHoldingsRecord> getProcessedType() {
     return ExtendedHoldingsRecord.class;
+  }
+
+  private boolean ruleTenantsAreNotValid(BulkOperationRule rule, Action action, ExtendedHoldingsRecord extendedHolding) {
+    var ruleTenants = rule.getRuleDetails().getTenants();
+    var actionTenants = action.getTenants();
+    return nonNull(ruleTenants) && !ruleTenants.isEmpty() && !ruleTenants.contains(extendedHolding.getTenant()) ||
+      nonNull(actionTenants) && !actionTenants.isEmpty() && !actionTenants.contains(extendedHolding.getTenant());
   }
 }

--- a/src/main/java/org/folio/bulkops/processor/HoldingsDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/HoldingsDataProcessor.java
@@ -50,7 +50,6 @@ public class HoldingsDataProcessor extends AbstractDataProcessor<ExtendedHolding
   private final HoldingsNotesUpdater holdingsNotesUpdater;
   private final ElectronicAccessUpdaterFactory electronicAccessUpdaterFactory;
   private final ElectronicAccessReferenceService electronicAccessReferenceService;
-  private final FolioExecutionContext folioExecutionContext;
 
   private static final Pattern UUID_REGEX =
     Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");

--- a/src/main/java/org/folio/bulkops/processor/ItemDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/ItemDataProcessor.java
@@ -63,14 +63,15 @@ public class ItemDataProcessor extends AbstractDataProcessor<ExtendedItem> {
             .getValue()).contains(action.getUpdated())) {
         throw new RuleValidationException(
             format("New status value \"%s\" is not allowed", action.getUpdated()));
-      } else if (ruleTenantsAreNotValid(rule, action, extendedItem)) {
-        throw new RuleValidationTenantsException(String.format(RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE, extendedItem.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), extendedItem.getTenant(), option.getValue()));
       }
     };
   }
 
   @Override
-  public Updater<ExtendedItem> updater(UpdateOptionType option, Action action) {
+  public Updater<ExtendedItem> updater(UpdateOptionType option, Action action, ExtendedItem entity, BulkOperationRule rule) throws RuleValidationTenantsException {
+    if (ruleTenantsAreNotValid(rule, action, entity)) {
+      throw new RuleValidationTenantsException(String.format(RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE, entity.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), entity.getTenant(), option.getValue()));
+    }
     if (REPLACE_WITH == action.getType()) {
       return switch (option) {
         case PERMANENT_LOAN_TYPE ->

--- a/src/main/java/org/folio/bulkops/processor/ItemDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/ItemDataProcessor.java
@@ -26,7 +26,6 @@ import org.folio.bulkops.exception.BulkOperationException;
 import org.folio.bulkops.exception.RuleValidationException;
 import org.folio.bulkops.service.HoldingsReferenceService;
 import org.folio.bulkops.service.ItemReferenceService;
-import org.folio.spring.FolioExecutionContext;
 import org.springframework.stereotype.Component;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/folio/bulkops/processor/ItemDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/ItemDataProcessor.java
@@ -39,7 +39,6 @@ public class ItemDataProcessor extends AbstractDataProcessor<ExtendedItem> {
   private final HoldingsReferenceService holdingsReferenceService;
   private final ItemReferenceService itemReferenceService;
   private final ItemsNotesUpdater itemsNotesUpdater;
-  private final FolioExecutionContext folioExecutionContext;
 
   @Override
   public Validator<UpdateOptionType, Action> validator(ExtendedItem extendedItem) {

--- a/src/main/java/org/folio/bulkops/processor/ItemDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/ItemDataProcessor.java
@@ -63,9 +63,7 @@ public class ItemDataProcessor extends AbstractDataProcessor<ExtendedItem> {
             .getValue()).contains(action.getUpdated())) {
         throw new RuleValidationException(
             format("New status value \"%s\" is not allowed", action.getUpdated()));
-      } else if (nonNull(rule.getRuleDetails().getTenants()) && !rule.getRuleDetails().getTenants().isEmpty() && !rule.getRuleDetails().getTenants().contains(extendedItem.getTenant())
-        ||
-        nonNull(action.getTenants()) && !action.getTenants().isEmpty() && !action.getTenants().contains(extendedItem.getTenant())) {
+      } else if (ruleTenantsAreNotValid(rule, action, extendedItem)) {
         throw new RuleValidationTenantsException(String.format(RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE, extendedItem.getIdentifier(org.folio.bulkops.domain.dto.IdentifierType.ID), extendedItem.getTenant(), option.getValue()));
       }
     };
@@ -161,6 +159,13 @@ public class ItemDataProcessor extends AbstractDataProcessor<ExtendedItem> {
     } else {
       return isNull(item.getTemporaryLocation()) ? item.getPermanentLocation() : item.getTemporaryLocation();
     }
+  }
+
+  private boolean ruleTenantsAreNotValid(BulkOperationRule rule, Action action, ExtendedItem extendedItem) {
+    var ruleTenants = rule.getRuleDetails().getTenants();
+    var actionTenants = action.getTenants();
+    return nonNull(ruleTenants) && !ruleTenants.isEmpty() && !ruleTenants.contains(extendedItem.getTenant()) ||
+      nonNull(actionTenants) && !actionTenants.isEmpty() && !actionTenants.contains(extendedItem.getTenant());
   }
 }
 

--- a/src/main/java/org/folio/bulkops/processor/UserDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/UserDataProcessor.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import org.folio.bulkops.domain.bean.User;
 import org.folio.bulkops.domain.dto.Action;
 import org.folio.bulkops.domain.dto.UpdateOptionType;
+import org.folio.bulkops.domain.dto.BulkOperationRule;
 import org.folio.bulkops.exception.BulkOperationException;
 import org.folio.bulkops.exception.RuleValidationException;
 import org.folio.bulkops.service.UserReferenceService;
@@ -33,8 +34,8 @@ public class UserDataProcessor extends AbstractDataProcessor<User> {
   private final UserReferenceService userReferenceService;
 
   @Override
-  public Validator<UpdateOptionType, Action> validator(User entity) {
-    return (option, action) -> {
+  public Validator<UpdateOptionType, Action, BulkOperationRule> validator(User entity) {
+    return (option, action, rule) -> {
       if (EXPIRATION_DATE == option) {
         if (action.getType() != REPLACE_WITH) {
           throw new RuleValidationException(

--- a/src/main/java/org/folio/bulkops/processor/UserDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/UserDataProcessor.java
@@ -64,7 +64,7 @@ public class UserDataProcessor extends AbstractDataProcessor<User> {
   }
 
   @Override
-  public Updater<User> updater(UpdateOptionType option, Action action) {
+  public Updater<User> updater(UpdateOptionType option, Action action, User entity, BulkOperationRule rule) {
     return switch (option) {
       case PATRON_GROUP -> user -> user.setPatronGroup(action.getUpdated());
       case EXPIRATION_DATE -> user -> {

--- a/src/main/java/org/folio/bulkops/processor/Validator.java
+++ b/src/main/java/org/folio/bulkops/processor/Validator.java
@@ -1,8 +1,9 @@
 package org.folio.bulkops.processor;
 
 import org.folio.bulkops.exception.RuleValidationException;
+import org.folio.bulkops.exception.RuleValidationTenantsException;
 
 @FunctionalInterface
-public interface Validator<T, U> {
-    void validate(T t, U u) throws RuleValidationException;
+public interface Validator<T, U, V> {
+    void validate(T t, U u, V v) throws RuleValidationException, RuleValidationTenantsException;
 }

--- a/src/main/java/org/folio/bulkops/service/ConsortiaService.java
+++ b/src/main/java/org/folio/bulkops/service/ConsortiaService.java
@@ -29,10 +29,10 @@ public class ConsortiaService {
     var userTenantCollection = consortiaClient.getUserTenantCollection();
     var userTenants = userTenantCollection.getUserTenants();
     if (!userTenants.isEmpty()) {
-      log.debug("userTenants: {}", userTenants);
+      log.info("userTenants: {}", userTenants);
       return userTenants.get(0).getCentralTenantId();
     }
-    log.debug("No central tenant found for {}", currentTenantId);
+    log.info("No central tenant found for {}", currentTenantId);
     return StringUtils.EMPTY;
   }
 

--- a/src/main/java/org/folio/bulkops/service/RuleService.java
+++ b/src/main/java/org/folio/bulkops/service/RuleService.java
@@ -47,6 +47,7 @@ public class RuleService {
           .initialValue(action.getInitial())
           .updatedValue(action.getUpdated())
           .parameters(action.getParameters())
+          .tenants(action.getTenants())
           .build()));
     });
     return ruleCollection;
@@ -72,7 +73,8 @@ public class RuleService {
             .type(details.getUpdateAction())
             .initial(details.getInitialValue())
             .updated(details.getUpdatedValue())
-            .parameters(details.getParameters()))
+            .parameters(details.getParameters())
+            .tenants(details.getTenants()))
           .toList()));
   }
 

--- a/src/main/java/org/folio/bulkops/util/Constants.java
+++ b/src/main/java/org/folio/bulkops/util/Constants.java
@@ -62,6 +62,7 @@ public class Constants {
   public static final String MSG_ERROR_OPTIMISTIC_LOCKING_DEFAULT = "The record cannot be saved because it is not the most recent version.";
 
   public static final String CSV_MSG_ERROR_TEMPLATE_OPTIMISTIC_LOCKING = "The record cannot be saved because it is not the most recent version. Stored version is %s, bulk edit version is %s.";
+  public static final String RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE = "%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.";
   public static final String ITEM_TYPE = "ITEM";
   public static final String HOLDING_TYPE = "HOLDINGS_RECORD";
   public static final Set<String> SPLIT_NOTE_ENTITIES = Set.of(ITEM_TYPE, HOLDING_TYPE);

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -30,4 +30,5 @@
   <include file="changes/14-06-2024_add_marc_links_to_bulk_operation_table.xml" relativeToChangelogFile="true"/>
   <include file="changes/18-06-2024_updates_for_editing_marc.xml" relativeToChangelogFile="true"/>
   <include file="changes/29-08-2024_add_used_tenants.xml" relativeToChangelogFile="true"/>
+  <include file="changes/20-09-2024_add_tenants_to_rules.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/20-09-2024_add_tenants_to_rules.sql
+++ b/src/main/resources/db/changelog/changes/20-09-2024_add_tenants_to_rules.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bulk_operation_rule_details
+ADD COLUMN IF NOT EXISTS tenants TEXT[];

--- a/src/main/resources/db/changelog/changes/20-09-2024_add_tenants_to_rules.xml
+++ b/src/main/resources/db/changelog/changes/20-09-2024_add_tenants_to_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+
+  <changeSet id="20-09-2024_add_tenants_to_rules.sql" author="firebird">
+    <sqlFile path="20-09-2024_add_tenants_to_rules.sql" relativeToChangelogFile="true" />
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/swagger.api/schemas/action.json
+++ b/src/main/resources/swagger.api/schemas/action.json
@@ -21,6 +21,12 @@
         "items": {
           "$ref": "action_parameter.json#/Parameter"
         }
+      },
+      "tenants": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "required": [

--- a/src/main/resources/swagger.api/schemas/bulk_operation_rule.json
+++ b/src/main/resources/swagger.api/schemas/bulk_operation_rule.json
@@ -22,6 +22,12 @@
             "description": "Option to change",
             "$ref": "update_option_type.json#/UpdateOptionType"
           },
+          "tenants": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "actions": {
             "type": "array",
             "items": {

--- a/src/test/java/org/folio/bulkops/BaseTest.java
+++ b/src/test/java/org/folio/bulkops/BaseTest.java
@@ -298,6 +298,14 @@ public abstract class BaseTest {
     return rule(option, action, null, updated);
   }
 
+  public static BulkOperationRule rule(UpdateOptionType option, UpdateActionType action, String updated,
+                                       List<String> actionsTenants, List<String> ruleTenants) {
+    var rule = rule(option, action, null, updated);
+    rule.getRuleDetails().setTenants(ruleTenants);
+    rule.getRuleDetails().getActions().get(0).setTenants(actionsTenants);
+    return rule;
+  }
+
   public BulkOperation buildBulkOperation(String fileName, org.folio.bulkops.domain.dto.EntityType entityType, org.folio.bulkops.domain.dto.BulkOperationStep step) {
     return switch (step) {
       case UPLOAD -> BulkOperation.builder()

--- a/src/test/java/org/folio/bulkops/processor/FolioInstanceDataProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/FolioInstanceDataProcessorTest.java
@@ -385,7 +385,7 @@ class FolioInstanceDataProcessorTest extends BaseTest {
     var extendedInstance = ExtendedInstance.builder().entity(instance).tenantId("tenantId").build();
     var validator = ((FolioInstanceDataProcessor) processor).validator(extendedInstance);
 
-    assertThrows(RuleValidationException.class, () -> validator.validate(INSTANCE_NOTE, new Action().type(actionType)));
+    assertThrows(RuleValidationException.class, () -> validator.validate(INSTANCE_NOTE, new Action().type(actionType), new BulkOperationRule()));
   }
 
   @Test
@@ -398,6 +398,6 @@ class FolioInstanceDataProcessorTest extends BaseTest {
     var extendedInstance = ExtendedInstance.builder().entity(instance).tenantId("tenantId").build();
     var validator = ((FolioInstanceDataProcessor) processor).validator(extendedInstance);
 
-    assertThrows(RuleValidationException.class, () -> validator.validate(ADMINISTRATIVE_NOTE, new Action().type(CHANGE_TYPE)));
+    assertThrows(RuleValidationException.class, () -> validator.validate(ADMINISTRATIVE_NOTE, new Action().type(CHANGE_TYPE), new BulkOperationRule()));
   }
 }

--- a/src/test/java/org/folio/bulkops/processor/HoldingsDataProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/HoldingsDataProcessorTest.java
@@ -47,6 +47,8 @@ import org.folio.bulkops.domain.bean.HoldingsRecord;
 import org.folio.bulkops.domain.bean.HoldingsRecordsSource;
 import org.folio.bulkops.domain.bean.ItemLocation;
 import org.folio.bulkops.domain.dto.Action;
+import org.folio.bulkops.domain.dto.BulkOperationRuleRuleDetails;
+import org.folio.bulkops.domain.dto.BulkOperationRule;
 import org.folio.bulkops.domain.dto.Parameter;
 import org.folio.bulkops.domain.dto.UpdateOptionType;
 import org.folio.bulkops.exception.NotFoundException;
@@ -291,13 +293,13 @@ class HoldingsDataProcessorTest extends BaseTest {
 
     var processor = new HoldingsDataProcessor(null, null, null, null, null);
 
-    processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_TRUE)).apply(extendedHoldingsRecord);
+    processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_TRUE), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertTrue(holdingsRecord.getDiscoverySuppress());
-    processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_FALSE)).apply(extendedHoldingsRecord);
+    processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_FALSE), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertFalse(holdingsRecord.getDiscoverySuppress());
-    processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_TRUE_INCLUDING_ITEMS)).apply(extendedHoldingsRecord);
+    processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_TRUE_INCLUDING_ITEMS), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertTrue(holdingsRecord.getDiscoverySuppress());
-    processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_FALSE_INCLUDING_ITEMS)).apply(extendedHoldingsRecord);
+    processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_FALSE_INCLUDING_ITEMS), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertFalse(holdingsRecord.getDiscoverySuppress());
   }
 
@@ -314,7 +316,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     parameter.setValue("typeId");
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
-    processor.updater(HOLDINGS_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedHoldingsRecord);
+    processor.updater(HOLDINGS_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter)), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     assertTrue(holding.getNotes().get(0).getStaffOnly());
   }
@@ -332,7 +334,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     parameter.setValue("typeId");
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
-    processor.updater(HOLDINGS_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedHoldingsRecord);
+    processor.updater(HOLDINGS_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter)), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     assertFalse(holding.getNotes().get(0).getStaffOnly());
   }
@@ -346,7 +348,7 @@ class HoldingsDataProcessorTest extends BaseTest {
 
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(REMOVE_ALL)).apply(extendedHoldingsRecord);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(REMOVE_ALL), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertTrue(holding.getAdministrativeNotes().isEmpty());
   }
 
@@ -362,7 +364,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     parameter.setValue("typeId1");
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
-    processor.updater(HOLDINGS_NOTE, new Action().type(REMOVE_ALL).parameters(List.of(parameter))).apply(extendedHoldingsRecord);
+    processor.updater(HOLDINGS_NOTE, new Action().type(REMOVE_ALL).parameters(List.of(parameter)), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(1, holding.getNotes().size());
     assertEquals("typeId2", holding.getNotes().get(0).getHoldingsNoteTypeId());
   }
@@ -376,11 +378,11 @@ class HoldingsDataProcessorTest extends BaseTest {
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote1)).apply(extendedHoldingsRecord);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote1), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(1, holding.getAdministrativeNotes().size());
     assertEquals(administrativeNote1, holding.getAdministrativeNotes().get(0));
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote2)).apply(extendedHoldingsRecord);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote2), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(2, holding.getAdministrativeNotes().size());
   }
 
@@ -397,7 +399,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
-    processor.updater(HOLDINGS_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(note1)).apply(extendedHoldingsRecord);
+    processor.updater(HOLDINGS_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(note1), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     assertEquals(1, holding.getNotes().size());
     assertEquals("typeId1", holding.getNotes().get(0).getHoldingsNoteTypeId());
@@ -405,7 +407,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     assertEquals(false, holding.getNotes().get(0).getStaffOnly());
 
     parameter.setValue("typeId2");
-    processor.updater(HOLDINGS_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(note2)).apply(extendedHoldingsRecord);
+    processor.updater(HOLDINGS_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(note2), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     assertEquals(2, holding.getNotes().size());
     assertEquals("typeId2", holding.getNotes().get(1).getHoldingsNoteTypeId());
@@ -414,7 +416,7 @@ class HoldingsDataProcessorTest extends BaseTest {
 
     parameter.setValue("typeId3");
     List<Parameter> params = List.of(new Parameter().key(STAFF_ONLY_NOTE_PARAMETER_KEY).value("true"), parameter);
-    processor.updater(HOLDINGS_NOTE, new Action().type(ADD_TO_EXISTING).parameters(params).updated(note3)).apply(extendedHoldingsRecord);
+    processor.updater(HOLDINGS_NOTE, new Action().type(ADD_TO_EXISTING).parameters(params).updated(note3), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(3, holding.getNotes().size());
     assertEquals("typeId3", holding.getNotes().get(2).getHoldingsNoteTypeId());
     assertEquals(note3, holding.getNotes().get(2).getNote());
@@ -430,10 +432,10 @@ class HoldingsDataProcessorTest extends BaseTest {
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("administrative note")).apply(extendedHoldingsRecord);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("administrative note"), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(2, holding.getAdministrativeNotes().size());
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial(administrativeNote2)).apply(extendedHoldingsRecord);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial(administrativeNote2), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(1, holding.getAdministrativeNotes().size());
     assertEquals(administrativeNote1, holding.getAdministrativeNotes().get(0));
   }
@@ -452,13 +454,13 @@ class HoldingsDataProcessorTest extends BaseTest {
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("note")
-      .parameters(List.of(parameter))).apply(extendedHoldingsRecord);
+      .parameters(List.of(parameter)), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(3, holding.getNotes().size());
     processor.updater(HOLDINGS_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("note1")
-      .parameters(List.of(parameter))).apply(extendedHoldingsRecord);
+      .parameters(List.of(parameter)), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(2, holding.getNotes().size());
     processor.updater(HOLDINGS_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("note2")
-      .parameters(List.of(parameter))).apply(extendedHoldingsRecord);
+      .parameters(List.of(parameter)), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(1, holding.getNotes().size());
   }
 
@@ -473,7 +475,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REPLACE)
-      .initial(administrativeNote1).updated(administrativeNote3)).apply(extendedHoldingsRecord);
+      .initial(administrativeNote1).updated(administrativeNote3), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(2, holding.getAdministrativeNotes().size());
     assertEquals(administrativeNote3, holding.getAdministrativeNotes().get(0));
     assertEquals(administrativeNote2, holding.getAdministrativeNotes().get(1));
@@ -492,7 +494,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(FIND_AND_REPLACE).parameters(List.of(parameter))
-      .initial("note1").updated("note3")).apply(extendedHoldingsRecord);
+      .initial("note1").updated("note3"), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     assertEquals("note3", holding.getNotes().get(0).getNote());
     assertEquals("note1", holding.getNotes().get(1).getNote());
@@ -507,7 +509,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(CHANGE_TYPE)
-      .updated("typeId")).apply(extendedHoldingsRecord);
+      .updated("typeId"), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(0, holding.getAdministrativeNotes().size());
     assertEquals("note", holding.getNotes().get(0).getNote());
     assertEquals("typeId", holding.getNotes().get(0).getHoldingsNoteTypeId());
@@ -525,7 +527,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
     var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
-    processor.updater(HOLDINGS_NOTE, new Action().type(CHANGE_TYPE).updated(ADMINISTRATIVE_NOTE.getValue()).parameters(List.of(parameter))).apply(extendedHoldingsRecord);
+    processor.updater(HOLDINGS_NOTE, new Action().type(CHANGE_TYPE).updated(ADMINISTRATIVE_NOTE.getValue()).parameters(List.of(parameter)), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     assertEquals(1, holding.getAdministrativeNotes().size());
     assertEquals("note1", holding.getAdministrativeNotes().get(0));
@@ -535,7 +537,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     holding.setAdministrativeNotes(null);
     holding.setNotes(List.of(note1, note2));
 
-    processor.updater(HOLDINGS_NOTE, new Action().type(CHANGE_TYPE).updated("typeId3").parameters(List.of(parameter))).apply(extendedHoldingsRecord);
+    processor.updater(HOLDINGS_NOTE, new Action().type(CHANGE_TYPE).updated("typeId3").parameters(List.of(parameter)), extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
     assertEquals(2, holding.getNotes().size());
     assertEquals("note1", holding.getNotes().get(0).getNote());
     assertEquals("typeId3", holding.getNotes().get(0).getHoldingsNoteTypeId());
@@ -591,7 +593,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var action = new Action().type(CLEAR_FIELD);
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holdingsRecord).tenantId("tenant").build();
 
-    processor.updater(option, action).apply(extendedHoldingsRecord);
+    processor.updater(option, action, extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     var electronicAccess = holdingsRecord.getElectronicAccess().get(0);
     switch (option) {
@@ -618,7 +620,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null);
     var action = new Action().type(FIND_AND_REMOVE_THESE).initial(value);
 
-    processor.updater(option, action).apply(extendedHoldingsRecord);
+    processor.updater(option, action, extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     var modified = holdingsRecord.getElectronicAccess().get(0);
     var unmodified = holdingsRecord.getElectronicAccess().get(1);
@@ -663,7 +665,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null);
     var action = new Action().type(REPLACE_WITH).updated(newValue);
 
-    processor.updater(option, action).apply(extendedHoldingsRecord);
+    processor.updater(option, action, extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     var electronicAccess = holdingsRecord.getElectronicAccess().get(0);
     switch (option) {
@@ -690,7 +692,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null);
     var action = new Action().type(FIND_AND_REPLACE).initial(initial).updated(updated);
 
-    processor.updater(option, action).apply(extendedHoldingsRecord);
+    processor.updater(option, action, extendedHoldingsRecord, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedHoldingsRecord);
 
     var modified = holdingsRecord.getElectronicAccess().get(0);
     var unmodified = holdingsRecord.getElectronicAccess().get(1);

--- a/src/test/java/org/folio/bulkops/processor/HoldingsDataProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/HoldingsDataProcessorTest.java
@@ -276,7 +276,7 @@ class HoldingsDataProcessorTest extends BaseTest {
       .withDiscoverySuppress(false);
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holdingsRecord).tenantId("tenant").build();
 
-    var processor = new HoldingsDataProcessor(null, null, null, null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, null, null, null);
 
     processor.updater(SUPPRESS_FROM_DISCOVERY, new Action().type(SET_TO_TRUE)).apply(extendedHoldingsRecord);
     assertTrue(holdingsRecord.getDiscoverySuppress());
@@ -299,7 +299,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var parameter = new Parameter();
     parameter.setKey(HOLDINGS_NOTE_TYPE_ID_KEY);
     parameter.setValue("typeId");
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedHoldingsRecord);
 
@@ -317,7 +317,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var parameter = new Parameter();
     parameter.setKey(HOLDINGS_NOTE_TYPE_ID_KEY);
     parameter.setValue("typeId");
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedHoldingsRecord);
 
@@ -331,7 +331,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var holding =  new HoldingsRecord().withAdministrativeNotes(List.of(administrativeNote));
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
 
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(REMOVE_ALL)).apply(extendedHoldingsRecord);
     assertTrue(holding.getAdministrativeNotes().isEmpty());
@@ -347,7 +347,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var parameter = new Parameter();
     parameter.setKey(HOLDINGS_NOTE_TYPE_ID_KEY);
     parameter.setValue("typeId1");
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(REMOVE_ALL).parameters(List.of(parameter))).apply(extendedHoldingsRecord);
     assertEquals(1, holding.getNotes().size());
@@ -361,7 +361,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var administrativeNote2 = "administrative note 2";
     var holding = new HoldingsRecord();
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote1)).apply(extendedHoldingsRecord);
     assertEquals(1, holding.getAdministrativeNotes().size());
@@ -382,7 +382,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     parameter.setKey(HOLDINGS_NOTE_TYPE_ID_KEY);
     parameter.setValue("typeId1");
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(note1)).apply(extendedHoldingsRecord);
 
@@ -415,7 +415,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var administrativeNote2 = "administrative note 2";
     var holding = new HoldingsRecord().withAdministrativeNotes(new ArrayList<>(List.of(administrativeNote1, administrativeNote2)));
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("administrative note")).apply(extendedHoldingsRecord);
     assertEquals(2, holding.getAdministrativeNotes().size());
@@ -436,7 +436,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     parameter.setValue("typeId1");
     var holding = new HoldingsRecord().withNotes(List.of(note1, note2, note3));
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("note")
       .parameters(List.of(parameter))).apply(extendedHoldingsRecord);
@@ -457,7 +457,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var administrativeNote3 = "administrative note 3";
     var holding = new HoldingsRecord().withAdministrativeNotes(new ArrayList<>(List.of(administrativeNote1, administrativeNote2)));
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REPLACE)
       .initial(administrativeNote1).updated(administrativeNote3)).apply(extendedHoldingsRecord);
@@ -476,7 +476,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     parameter.setValue("typeId1");
     var holding = new HoldingsRecord().withNotes(List.of(note1, note2));
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(FIND_AND_REPLACE).parameters(List.of(parameter))
       .initial("note1").updated("note3")).apply(extendedHoldingsRecord);
@@ -491,7 +491,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     var administrativeNote = "note";
     var holding = new HoldingsRecord().withAdministrativeNotes(new ArrayList<>(List.of(administrativeNote)));
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(CHANGE_TYPE)
       .updated("typeId")).apply(extendedHoldingsRecord);
@@ -510,7 +510,7 @@ class HoldingsDataProcessorTest extends BaseTest {
     parameter.setValue("typeId1");
     var holding = new HoldingsRecord().withNotes(List.of(note1, note2));
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holding).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
 
     processor.updater(HOLDINGS_NOTE, new Action().type(CHANGE_TYPE).updated(ADMINISTRATIVE_NOTE.getValue()).parameters(List.of(parameter))).apply(extendedHoldingsRecord);
 
@@ -533,7 +533,7 @@ class HoldingsDataProcessorTest extends BaseTest {
   @Test
   @SneakyThrows
   void testClone() {
-    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, new HoldingsNotesUpdater(new AdministrativeNotesUpdater()), null, null);
     var administrativeNotes = new ArrayList<String>();
     administrativeNotes.add("note1");
     var holding1 = new HoldingsRecord().withId("id")
@@ -574,7 +574,7 @@ class HoldingsDataProcessorTest extends BaseTest {
   void shouldClearElectronicAccessFields(UpdateOptionType option) {
     var holdingsRecord = buildHoldingsWithElectronicAccess();
 
-    var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null);
     var action = new Action().type(CLEAR_FIELD);
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holdingsRecord).tenantId("tenant").build();
 
@@ -602,7 +602,7 @@ class HoldingsDataProcessorTest extends BaseTest {
   void shouldFindAndClearExactlyMatchedElectronicAccessFields(UpdateOptionType option, String value) {
     var holdingsRecord = buildHoldingsWithElectronicAccess();
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holdingsRecord).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null);
     var action = new Action().type(FIND_AND_REMOVE_THESE).initial(value);
 
     processor.updater(option, action).apply(extendedHoldingsRecord);
@@ -647,7 +647,7 @@ class HoldingsDataProcessorTest extends BaseTest {
   void shouldReplaceElectronicAccessFields(UpdateOptionType option, String newValue) {
     var holdingsRecord = buildHoldingsWithElectronicAccess();
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holdingsRecord).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null);
     var action = new Action().type(REPLACE_WITH).updated(newValue);
 
     processor.updater(option, action).apply(extendedHoldingsRecord);
@@ -674,7 +674,7 @@ class HoldingsDataProcessorTest extends BaseTest {
   void shouldFindAndReplaceExactlyMatchedElectronicAccessFields(UpdateOptionType option, String initial, String updated) {
     var holdingsRecord = buildHoldingsWithElectronicAccess();
     var extendedHoldingsRecord = ExtendedHoldingsRecord.builder().entity(holdingsRecord).tenantId("tenant").build();
-    var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null, folioExecutionContext);
+    var processor = new HoldingsDataProcessor(null, null, null, new ElectronicAccessUpdaterFactory(), null);
     var action = new Action().type(FIND_AND_REPLACE).initial(initial).updated(updated);
 
     processor.updater(option, action).apply(extendedHoldingsRecord);

--- a/src/test/java/org/folio/bulkops/processor/ItemDataProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/ItemDataProcessorTest.java
@@ -59,6 +59,8 @@ import org.folio.bulkops.domain.dto.Action;
 import org.folio.bulkops.domain.dto.Parameter;
 import org.folio.bulkops.domain.dto.UpdateActionType;
 import org.folio.bulkops.domain.dto.UpdateOptionType;
+import org.folio.bulkops.domain.dto.BulkOperationRuleRuleDetails;
+import org.folio.bulkops.domain.dto.BulkOperationRule;
 import org.folio.bulkops.repository.BulkOperationExecutionContentRepository;
 import org.folio.bulkops.service.ConsortiaService;
 import org.folio.bulkops.service.ErrorService;
@@ -340,7 +342,7 @@ class ItemDataProcessorTest extends BaseTest {
     parameter.setValue("typeId");
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ITEM_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
 
     assertTrue(item.getNotes().get(0).getStaffOnly());
   }
@@ -356,7 +358,7 @@ class ItemDataProcessorTest extends BaseTest {
     parameter.setValue("typeId");
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ITEM_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
 
     assertFalse(item.getNotes().get(0).getStaffOnly());
   }
@@ -372,13 +374,13 @@ class ItemDataProcessorTest extends BaseTest {
     parameter.setValue("typeId");
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(CHECK_IN_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(CHECK_IN_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertTrue(item.getCirculationNotes().get(0).getStaffOnly());
 
     circulationNote.setStaffOnly(false);
     circulationNote.setNoteType(CirculationNote.NoteTypeEnum.OUT);
 
-    processor.updater(CHECK_OUT_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(MARK_AS_STAFF_ONLY).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertTrue(item.getCirculationNotes().get(0).getStaffOnly());
   }
 
@@ -393,13 +395,13 @@ class ItemDataProcessorTest extends BaseTest {
     parameter.setValue("typeId");
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(CHECK_IN_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(CHECK_IN_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertFalse(item.getCirculationNotes().get(0).getStaffOnly());
 
     circulationNote.setStaffOnly(true);
     circulationNote.setNoteType(CirculationNote.NoteTypeEnum.OUT);
 
-    processor.updater(CHECK_OUT_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(REMOVE_MARK_AS_STAFF_ONLY).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertFalse(item.getCirculationNotes().get(0).getStaffOnly());
   }
 
@@ -411,7 +413,7 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(REMOVE_ALL)).apply(extendedItem);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(REMOVE_ALL), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertTrue(item.getAdministrativeNotes().isEmpty());
   }
 
@@ -424,12 +426,12 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(CHECK_IN_NOTE, new Action().type(REMOVE_ALL)).apply(extendedItem);
+    processor.updater(CHECK_IN_NOTE, new Action().type(REMOVE_ALL), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
 
     item.setCirculationNotes(List.of(checkInNote, checkOutNote));
-    processor.updater(CHECK_OUT_NOTE, new Action().type(REMOVE_ALL)).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(REMOVE_ALL), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals(CirculationNote.NoteTypeEnum.IN, item.getCirculationNotes().get(0).getNoteType());
   }
@@ -442,8 +444,8 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(CHECK_IN_NOTE, new Action().type(REMOVE_ALL)).apply(extendedItem);
-    processor.updater(CHECK_OUT_NOTE, new Action().type(ADD_TO_EXISTING)).apply(extendedItem);
+    processor.updater(CHECK_IN_NOTE, new Action().type(REMOVE_ALL), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(ADD_TO_EXISTING), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
   }
@@ -459,8 +461,8 @@ class ItemDataProcessorTest extends BaseTest {
     parameter.setValue("typeId1");
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ITEM_NOTE, new Action().type(FIND_AND_REMOVE_THESE).parameters(List.of(parameter)).initial("Action note")).apply(extendedItem);
-    processor.updater(ITEM_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(FIND_AND_REMOVE_THESE).parameters(List.of(parameter)).initial("Action note"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getNotes().size());
     assertEquals("typeId1", item.getNotes().get(0).getItemNoteTypeId());
   }
@@ -477,7 +479,7 @@ class ItemDataProcessorTest extends BaseTest {
     parameter.setValue("typeId1");
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ITEM_NOTE, new Action().type(REMOVE_ALL).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(REMOVE_ALL).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getNotes().size());
     assertEquals("typeId2", item.getNotes().get(0).getItemNoteTypeId());
   }
@@ -491,11 +493,11 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote1)).apply(extendedItem);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote1), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getAdministrativeNotes().size());
     assertEquals(administrativeNote1, item.getAdministrativeNotes().get(0));
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote2)).apply(extendedItem);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(ADD_TO_EXISTING).updated(administrativeNote2), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getAdministrativeNotes().size());
   }
 
@@ -508,20 +510,20 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(CHECK_IN_NOTE, new Action().type(ADD_TO_EXISTING).updated(checkInNote)).apply(extendedItem);
+    processor.updater(CHECK_IN_NOTE, new Action().type(ADD_TO_EXISTING).updated(checkInNote), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals(checkInNote, item.getCirculationNotes().get(0).getNote());
     assertEquals(false, item.getCirculationNotes().get(0).getStaffOnly());
     assertEquals(CirculationNote.NoteTypeEnum.IN, item.getCirculationNotes().get(0).getNoteType());
 
-    processor.updater(CHECK_OUT_NOTE, new Action().type(ADD_TO_EXISTING).updated(checkOutNote)).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(ADD_TO_EXISTING).updated(checkOutNote), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getCirculationNotes().size());
     assertEquals(checkOutNote, item.getCirculationNotes().get(1).getNote());
     assertEquals(false, item.getCirculationNotes().get(1).getStaffOnly());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(1).getNoteType());
 
     List<Parameter> params = Collections.singletonList(new Parameter().key(STAFF_ONLY_NOTE_PARAMETER_KEY).value("true"));
-    processor.updater(CHECK_OUT_NOTE, new Action().type(ADD_TO_EXISTING).parameters(params).updated(checkOutNote)).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(ADD_TO_EXISTING).parameters(params).updated(checkOutNote), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(3, item.getCirculationNotes().size());
     assertEquals(checkOutNote, item.getCirculationNotes().get(2).getNote());
     assertEquals(true, item.getCirculationNotes().get(2).getStaffOnly());
@@ -541,14 +543,14 @@ class ItemDataProcessorTest extends BaseTest {
 
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ITEM_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(itemNote1)).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(itemNote1), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
 
     assertEquals(1, item.getNotes().size());
     assertEquals("typeId1", item.getNotes().get(0).getItemNoteTypeId());
     assertEquals(itemNote1, item.getNotes().get(0).getNote());
 
     parameter.setValue("typeId2");
-    processor.updater(ITEM_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(itemNote2)).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(ADD_TO_EXISTING).parameters(List.of(parameter)).updated(itemNote2), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
 
     assertEquals(2, item.getNotes().size());
     assertEquals("typeId2", item.getNotes().get(1).getItemNoteTypeId());
@@ -564,10 +566,10 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("administrative note")).apply(extendedItem);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("administrative note"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getAdministrativeNotes().size());
 
-    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial(administrativeNote2)).apply(extendedItem);
+    processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial(administrativeNote2), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getAdministrativeNotes().size());
     assertEquals(administrativeNote1, item.getAdministrativeNotes().get(0));
   }
@@ -583,15 +585,15 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(CHECK_OUT_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("note")).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("note"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getCirculationNotes().size());
-    processor.updater(CHECK_OUT_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("circ note")).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("circ note"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals("circ note", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.IN, item.getCirculationNotes().get(0).getNoteType());
 
     item.setCirculationNotes(List.of(checkInNote, checkOutNote));
-    processor.updater(CHECK_IN_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("circ note")).apply(extendedItem);
+    processor.updater(CHECK_IN_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("circ note"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals("circ note", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
@@ -611,13 +613,13 @@ class ItemDataProcessorTest extends BaseTest {
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
     processor.updater(ITEM_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("itemNote")
-      .parameters(List.of(parameter))).apply(extendedItem);
+      .parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(3, item.getNotes().size());
     processor.updater(ITEM_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("itemNote1")
-      .parameters(List.of(parameter))).apply(extendedItem);
+      .parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getNotes().size());
     processor.updater(ITEM_NOTE, new Action().type(FIND_AND_REMOVE_THESE).initial("itemNote2")
-      .parameters(List.of(parameter))).apply(extendedItem);
+      .parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getNotes().size());
   }
 
@@ -632,7 +634,7 @@ class ItemDataProcessorTest extends BaseTest {
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(FIND_AND_REPLACE)
-      .initial(administrativeNote1).updated(administrativeNote3)).apply(extendedItem);
+      .initial(administrativeNote1).updated(administrativeNote3), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getAdministrativeNotes().size());
     assertEquals(administrativeNote3, item.getAdministrativeNotes().get(0));
     assertEquals(administrativeNote2, item.getAdministrativeNotes().get(1));
@@ -650,7 +652,7 @@ class ItemDataProcessorTest extends BaseTest {
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
     processor.updater(CHECK_IN_NOTE, new Action().type(FIND_AND_REPLACE)
-      .initial("note").updated("note 2")).apply(extendedItem);
+      .initial("note").updated("note 2"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getCirculationNotes().size());
     assertEquals("note 2", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.IN, item.getCirculationNotes().get(0).getNoteType());
@@ -660,7 +662,7 @@ class ItemDataProcessorTest extends BaseTest {
     checkInNote.setNote("note");
 
     processor.updater(CHECK_OUT_NOTE, new Action().type(FIND_AND_REPLACE)
-      .initial("note").updated("note 2")).apply(extendedItem);
+      .initial("note").updated("note 2"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getCirculationNotes().size());
     assertEquals("note", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.IN, item.getCirculationNotes().get(0).getNoteType());
@@ -681,7 +683,7 @@ class ItemDataProcessorTest extends BaseTest {
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
     processor.updater(ITEM_NOTE, new Action().type(FIND_AND_REPLACE).parameters(List.of(parameter))
-      .initial("itemNote1").updated("itemNote3")).apply(extendedItem);
+      .initial("itemNote1").updated("itemNote3"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
 
     assertEquals("itemNote3", item.getNotes().get(0).getNote());
     assertEquals("itemNote1", item.getNotes().get(1).getNote());
@@ -696,7 +698,7 @@ class ItemDataProcessorTest extends BaseTest {
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(CHANGE_TYPE)
-      .updated(CHECK_IN_NOTE_TYPE)).apply(extendedItem);
+      .updated(CHECK_IN_NOTE_TYPE), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(0, item.getAdministrativeNotes().size());
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals("note", item.getCirculationNotes().get(0).getNote());
@@ -706,7 +708,7 @@ class ItemDataProcessorTest extends BaseTest {
     item.setAdministrativeNotes(List.of(administrativeNote));
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(CHANGE_TYPE)
-      .updated(CHECK_OUT_NOTE_TYPE)).apply(extendedItem);
+      .updated(CHECK_OUT_NOTE_TYPE), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(0, item.getAdministrativeNotes().size());
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals("note", item.getCirculationNotes().get(0).getNote());
@@ -716,7 +718,7 @@ class ItemDataProcessorTest extends BaseTest {
     item.setAdministrativeNotes(List.of(administrativeNote));
 
     processor.updater(ADMINISTRATIVE_NOTE, new Action().type(CHANGE_TYPE)
-      .updated("typeId")).apply(extendedItem);
+      .updated("typeId"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
 
     assertEquals(0, item.getAdministrativeNotes().size());
     assertEquals(1, item.getNotes().size());
@@ -736,7 +738,7 @@ class ItemDataProcessorTest extends BaseTest {
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
     processor.updater(CHECK_IN_NOTE, new Action().type(CHANGE_TYPE)
-      .updated(CHECK_OUT_NOTE_TYPE)).apply(extendedItem);
+      .updated(CHECK_OUT_NOTE_TYPE), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getCirculationNotes().size());
     assertEquals("note", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
@@ -745,7 +747,7 @@ class ItemDataProcessorTest extends BaseTest {
     checkInNote.setNoteType(CirculationNote.NoteTypeEnum.IN);
 
     processor.updater(CHECK_IN_NOTE, new Action().type(CHANGE_TYPE)
-      .updated(ADMINISTRATIVE_NOTE_TYPE)).apply(extendedItem);
+      .updated(ADMINISTRATIVE_NOTE_TYPE), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
     assertEquals(1, item.getAdministrativeNotes().size());
@@ -755,7 +757,7 @@ class ItemDataProcessorTest extends BaseTest {
     item.setCirculationNotes(List.of(checkInNote, checkOutNote));
 
     processor.updater(CHECK_IN_NOTE, new Action().type(CHANGE_TYPE)
-      .updated("typeId")).apply(extendedItem);
+      .updated("typeId"), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
     assertEquals(1, item.getNotes().size());
@@ -776,7 +778,7 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(ITEM_NOTE, new Action().type(CHANGE_TYPE).updated(ADMINISTRATIVE_NOTE_TYPE).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(CHANGE_TYPE).updated(ADMINISTRATIVE_NOTE_TYPE).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
 
     assertEquals(1, item.getAdministrativeNotes().size());
     assertEquals("itemNote1", item.getAdministrativeNotes().get(0));
@@ -786,7 +788,7 @@ class ItemDataProcessorTest extends BaseTest {
     item.setAdministrativeNotes(null);
     item.setNotes(List.of(itemNote1, itemNote2));
 
-    processor.updater(ITEM_NOTE, new Action().type(CHANGE_TYPE).updated(CHECK_IN_NOTE_TYPE).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(CHANGE_TYPE).updated(CHECK_IN_NOTE_TYPE).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals("itemNote1", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.IN, item.getCirculationNotes().get(0).getNoteType());
@@ -797,7 +799,7 @@ class ItemDataProcessorTest extends BaseTest {
     item.setCirculationNotes(null);
     item.setNotes(List.of(itemNote1, itemNote2));
 
-    processor.updater(ITEM_NOTE, new Action().type(CHANGE_TYPE).updated(CHECK_OUT_NOTE_TYPE).parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(CHANGE_TYPE).updated(CHECK_OUT_NOTE_TYPE).parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(1, item.getCirculationNotes().size());
     assertEquals("itemNote1", item.getCirculationNotes().get(0).getNote());
     assertEquals(CirculationNote.NoteTypeEnum.OUT, item.getCirculationNotes().get(0).getNoteType());
@@ -808,7 +810,7 @@ class ItemDataProcessorTest extends BaseTest {
     item.setCirculationNotes(null);
     item.setNotes(List.of(itemNote1, itemNote2));
 
-    processor.updater(ITEM_NOTE, new Action().type(CHANGE_TYPE).updated("typeId3").parameters(List.of(parameter))).apply(extendedItem);
+    processor.updater(ITEM_NOTE, new Action().type(CHANGE_TYPE).updated("typeId3").parameters(List.of(parameter)), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(2, item.getNotes().size());
     assertEquals("itemNote1", item.getNotes().get(0).getNote());
     assertEquals("typeId3", item.getNotes().get(0).getItemNoteTypeId());
@@ -827,7 +829,7 @@ class ItemDataProcessorTest extends BaseTest {
     var extendedItem = ExtendedItem.builder().entity(item).tenantId("tenant").build();
     var processor = new ItemDataProcessor(null, null, new ItemsNotesUpdater(new AdministrativeNotesUpdater()));
 
-    processor.updater(CHECK_IN_NOTE, new Action().type(DUPLICATE).updated(CHECK_OUT_NOTE_TYPE)).apply(extendedItem);
+    processor.updater(CHECK_IN_NOTE, new Action().type(DUPLICATE).updated(CHECK_OUT_NOTE_TYPE), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(3, item.getCirculationNotes().size());
     assertEquals(2, item.getCirculationNotes().stream().filter(circNote -> circNote.getNoteType() == CirculationNote.NoteTypeEnum.OUT).count());
     var duplicated = item.getCirculationNotes().stream().filter(circNote ->
@@ -835,7 +837,7 @@ class ItemDataProcessorTest extends BaseTest {
     assertTrue(duplicated.isPresent());
     assertTrue(duplicated.get().getStaffOnly());
 
-    processor.updater(CHECK_OUT_NOTE, new Action().type(DUPLICATE).updated(CHECK_IN_NOTE_TYPE)).apply(extendedItem);
+    processor.updater(CHECK_OUT_NOTE, new Action().type(DUPLICATE).updated(CHECK_IN_NOTE_TYPE), extendedItem, new BulkOperationRule().ruleDetails(new BulkOperationRuleRuleDetails())).apply(extendedItem);
     assertEquals(5, item.getCirculationNotes().size());
     assertEquals(3, item.getCirculationNotes().stream().filter(circNote -> circNote.getNoteType() == CirculationNote.NoteTypeEnum.IN).count());
 


### PR DESCRIPTION
[MODBULKOPS-334](https://folio-org.atlassian.net/browse/MODBULKOPS-334) - Preventing record update with values from different tenants 

## Purpose
In ECS environment, the user will be updating holdings and item records from multiple tenants.   Bulk edit should not allow to save the record that is associated with one tenant with locations that belong to another tenant. 

## Approach
Add column to rule details to store tenants, change schema.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
