### PR TITLE
MODBULKOPS-341 Added 'consortium' source

### DIFF
--- a/src/main/java/org/folio/bulkops/domain/bean/HoldingsRecordsSource.java
+++ b/src/main/java/org/folio/bulkops/domain/bean/HoldingsRecordsSource.java
@@ -28,7 +28,9 @@ public class HoldingsRecordsSource   {
   public enum SourceEnum {
     FOLIO("folio"),
 
-    LOCAL("local");
+    LOCAL("local"),
+
+    CONSORTIUM("consortium");
 
     private String value;
 

--- a/src/main/java/org/folio/bulkops/service/HoldingsReferenceService.java
+++ b/src/main/java/org/folio/bulkops/service/HoldingsReferenceService.java
@@ -148,6 +148,7 @@ public class HoldingsReferenceService {
         HoldingsRecordsSource.builder().name(EMPTY).build() :
         holdingsSourceClient.getById(id);
     } catch (Exception e) {
+      log.error(e);
       throw new NotFoundException(format("Holdings record source not found by id=%s", id));
     }
   }

--- a/src/test/java/org/folio/bulkops/service/HoldingsReferenceHelperTest.java
+++ b/src/test/java/org/folio/bulkops/service/HoldingsReferenceHelperTest.java
@@ -147,6 +147,11 @@ class HoldingsReferenceHelperTest extends BaseTest {
 
     when(holdingsSourceClient.getByQuery("name==\"name_4\"")).thenReturn(new HoldingsRecordsSourceCollection().withHoldingsRecordsSources(Collections.emptyList()));
     assertThrows(NotFoundException.class, () -> holdingsReferenceHelper.getSourceByName("name_4"));
+
+    when(holdingsSourceClient.getById("id_2")).thenReturn(new HoldingsRecordsSource().withName("name_2").withSource(HoldingsRecordsSource.SourceEnum.CONSORTIUM));
+    actual = holdingsReferenceHelper.getSourceById("id_2");
+    assertEquals("name_2", actual.getName());
+    assertEquals("consortium", actual.getSource().getValue());
   }
 
   @Test


### PR DESCRIPTION
[MODBULKOPS-341](https://folio-org.atlassian.net/browse/MODBULKOPS-341) - Errors on Confirmation screen when bulk edit Instances on ECS environment and apply changes to Holdings, Items

## Purpose
 The issue was found on large dataset (but also reproduced on small dataset with “Holdings record source not found by id=f32d531e-df79-46b3-8932-cdd35f7a2264“ error). When do bulk edit of ~100K Instance records then part of records goes to “Errors“ on Confirmation screen with the following reasons:

    96349fde-0e2b-5359-b36d-0625f9e69ab9,Holdings record source not found by id=f32d531e-df79-46b3-8932-cdd35f7a2264

    5968d412-e9e2-5430-8bf1-28357076eaf3,[401 Unauthorized] during [PUT] to [[http://inventory/instances/5968d412-e9e2-5430-8bf1-28357076eaf3]](http://inventory/instances/5968d412-e9e2-5430-8bf1-28357076eaf3%5D) [InstanceClient#updateInstance(Instance,String)]: [Invalid token]

    523bf227-864b-5570-8250-0d04ed7d5ec9,[500 Internal Server Error] during [PUT] to [[http://inventory/instances/523bf227-864b-5570-8250-0d04ed7d5ec9]](http://inventory/instances/523bf227-864b-5570-8250-0d04ed7d5ec9%5D) [InstanceClient#updateInstance(Instance,String)]: [proxyClient failure: mod-authtoken-2.16.0-SNAPSHOT.153 [http://mod-authtoken:](http://mod-authtoken/) finishConnect(..) failed: Connection refused: mod-authtoken.sprint.svc.cluster.local/172.20.219.80:80: PUT /inventory/instances/523bf227-864b-5570-8250-0d04ed7d5ec9]

The records going to “Errors“ are not updated (except error “Holdings record source not found by id=f32d531e-df79-46b3-8932-cdd35f7a2264“ - for them Instance is updated but Holdings, items are not updated). Other records are updated successfully

## Approach
Add 'consortium' source.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
