### PR TITLE
MODBULKOPS-434 - For Bulk edit of MARC Instances Confirmation screen fails to display when no changes are required

### DIFF
--- a/src/main/java/org/folio/bulkops/service/MarcUpdateService.java
+++ b/src/main/java/org/folio/bulkops/service/MarcUpdateService.java
@@ -1,5 +1,6 @@
 package org.folio.bulkops.service;
 
+import static java.util.Objects.nonNull;
 import static org.folio.bulkops.domain.dto.IdentifierType.HRID;
 import static org.folio.bulkops.domain.dto.OperationStatusType.FAILED;
 import static org.folio.bulkops.util.Constants.MARC;
@@ -61,8 +62,10 @@ public class MarcUpdateService {
         bulkOperation.setLinkToCommittedRecordsMarcFile(prepareCommittedFile(bulkOperation));
         updateProcessor.updateMarcRecords(bulkOperation);
         var path = bulkOperation.getLinkToCommittedRecordsMarcFile();
-        remoteFileSystemClient.remove(path);
-        bulkOperation.setLinkToCommittedRecordsMarcFile(null);
+        if (nonNull(path)) {
+          remoteFileSystemClient.remove(path);
+          bulkOperation.setLinkToCommittedRecordsMarcFile(null);
+        }
         bulkOperationRepository.save(bulkOperation);
         execution = execution
           .withStatus(StatusType.COMPLETED)


### PR DESCRIPTION
[MODBULKOPS-434](https://folio-org.atlassian.net/browse/MODBULKOPS-434) - For Bulk edit of MARC Instances Confirmation screen fails to display when no changes are required

## Purpose
 When do bulk edit of MARC Instances and select fields/actions that do not require changes then after clicking “Commit changes“ the bulk operation job fails and error appears "Error deleting file: " 

## Approach
Add check for null for path.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
