### PR TITLE
MODBULKOPS-456 - Files downloading improvement

### DIFF
--- a/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
+++ b/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
@@ -45,7 +45,7 @@ import org.folio.bulkops.service.RuleService;
 import org.folio.bulkops.service.UserPermissionsService;
 import org.folio.spring.cql.JpaCqlRepository;
 import org.folio.spring.data.OffsetRequest;
-import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -54,6 +54,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -183,12 +184,14 @@ public class BulkOperationController implements BulkOperationsApi {
         if (CSV_EXTENSION.equalsIgnoreCase(FilenameUtils.getExtension(path))) {
           content = getCsvContentWithUtf8Bom(content);
         }
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
-        headers.setContentLength(content.length);
         var decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+        HttpHeaders headers = new HttpHeaders();
         headers.setContentDispositionFormData(FileUtils.filename(decodedPath), FileUtils.filename(decodedPath));
-        return ResponseEntity.ok().headers(headers).body(new ByteArrayResource(content));
+        return ResponseEntity.ok()
+          .headers(headers)
+          .contentType(MediaType.APPLICATION_OCTET_STREAM)
+          .contentLength(content.length)
+          .body(new InputStreamResource(new ByteArrayInputStream(content)));
       } catch (IOException e) {
         log.error(e);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
[/MODBULKOPS-456](https://folio-org.atlassian.net/browse/MODBULKOPS-456) - Files downloading improvement

## Purpose
Download endpoint should return stream as it is done for mod-data-export to avoid extra memory consumption by sidecar.

## Approach
Replacement of ByteArrayResource by ByteArrayInputStream.

### TODOS and Open Questions
 <!-- OPTIONAL
 - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
 -->

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
