### PR TITLE
MODBULKOPS-377 - Create log with error message from another module

### DIFF
--- a/src/main/java/org/folio/bulkops/processor/marc/MarcInstanceUpdateProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/marc/MarcInstanceUpdateProcessor.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED;
 import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED_WITH_ERRORS;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
 import static org.folio.bulkops.util.Constants.MARC;
 
 import lombok.RequiredArgsConstructor;
@@ -70,7 +71,7 @@ public class MarcInstanceUpdateProcessor implements MarcUpdateProcessor {
         bulkOperation.setDataImportJobProfileId(UUID.fromString(jobProfile.getId()));
       } else {
         bulkOperation.setLinkToCommittedRecordsMarcFile(null);
-        bulkOperation.setLinkToCommittedRecordsErrorsCsvFile(errorService.uploadErrorsToStorage(bulkOperation.getId()));
+        bulkOperation.setLinkToCommittedRecordsErrorsCsvFile(errorService.uploadErrorsToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, null));
         bulkOperation.setCommittedNumOfErrors(errorService.getCommittedNumOfErrors(bulkOperation.getId()));
         bulkOperation.setCommittedNumOfWarnings(errorService.getCommittedNumOfWarnings(bulkOperation.getId()));
         bulkOperation.setEndTime(LocalDateTime.now());

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -497,7 +497,7 @@ public class BulkOperationService {
         operation.setStatus(OperationStatusType.FAILED);
         operation.setEndTime(LocalDateTime.now());
         operation.setErrorMessage(e.getMessage());
-        var linkToCommittingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
+        var linkToCommittingErrorsFile = errorService.uploadErrorsToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
         operation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
       }
       executionRepository.save(execution);
@@ -517,7 +517,7 @@ public class BulkOperationService {
       operation.setProcessedNumOfRecords(operation.getCommittedNumOfRecords());
       operation.setEndTime(LocalDateTime.now());
 
-      var linkToCommittingErrorsFile = errorService.uploadErrorsToStorage(operationId);
+      var linkToCommittingErrorsFile = errorService.uploadErrorsToStorage(operationId, ERROR_COMMITTING_FILE_NAME_PREFIX, null);
       operation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
       operation.setCommittedNumOfErrors(errorService.getCommittedNumOfErrors(operationId));
       operation.setCommittedNumOfWarnings(errorService.getCommittedNumOfWarnings(operationId));
@@ -551,7 +551,7 @@ public class BulkOperationService {
         operation.setStatus(FAILED);
         operation.setErrorMessage(errorMessage);
         operation.setEndTime(LocalDateTime.now());
-        var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX, errorMessage);
+        var linkToMatchingErrorsFile = errorService.uploadErrorsToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX, errorMessage);
         operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
       }
       bulkOperationRepository.save(operation);
@@ -780,7 +780,7 @@ public class BulkOperationService {
     operation.setErrorMessage(format(ERROR_MESSAGE_PATTERN, message, exception.getMessage()));
     operation.setStatus(FAILED);
     operation.setEndTime(LocalDateTime.now());
-    var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_MATCHING_FILE_NAME_PREFIX, operation.getErrorMessage());
+    var linkToMatchingErrorsFile = errorService.uploadErrorsToStorage(operation.getId(), ERROR_MATCHING_FILE_NAME_PREFIX, operation.getErrorMessage());
     operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
   }
 
@@ -793,7 +793,7 @@ public class BulkOperationService {
     operation.setErrorMessage(format(ERROR_MESSAGE_PATTERN, message, exception.getMessage()));
     operation.setStatus(OperationStatusType.FAILED);
     operation.setEndTime(LocalDateTime.now());
-    var linkToCommittingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
+    var linkToCommittingErrorsFile = errorService.uploadErrorsToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
     operation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
     bulkOperationRepository.save(operation);
   }

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -24,6 +24,8 @@ import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
 import static org.folio.bulkops.domain.dto.OperationStatusType.SAVED_IDENTIFIERS;
 import static org.folio.bulkops.domain.dto.OperationStatusType.SAVING_RECORDS_LOCALLY;
 import static org.folio.bulkops.service.MarcUpdateService.CHANGED_MARC_PATH_TEMPLATE;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
+import static org.folio.bulkops.util.Constants.ERROR_MATCHING_FILE_NAME_PREFIX;
 import static org.folio.bulkops.util.Constants.FIELD_ERROR_MESSAGE_PATTERN;
 import static org.folio.bulkops.util.Constants.MARC;
 import static org.folio.bulkops.util.ErrorCode.ERROR_MESSAGE_PATTERN;
@@ -495,6 +497,8 @@ public class BulkOperationService {
         operation.setStatus(OperationStatusType.FAILED);
         operation.setEndTime(LocalDateTime.now());
         operation.setErrorMessage(e.getMessage());
+        var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
+        operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
       }
       executionRepository.save(execution);
     }
@@ -547,6 +551,8 @@ public class BulkOperationService {
         operation.setStatus(FAILED);
         operation.setErrorMessage(errorMessage);
         operation.setEndTime(LocalDateTime.now());
+        var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX, errorMessage);
+        operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
       }
       bulkOperationRepository.save(operation);
       return operation;
@@ -774,6 +780,8 @@ public class BulkOperationService {
     operation.setErrorMessage(format(ERROR_MESSAGE_PATTERN, message, exception.getMessage()));
     operation.setStatus(FAILED);
     operation.setEndTime(LocalDateTime.now());
+    var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_MATCHING_FILE_NAME_PREFIX, operation.getErrorMessage());
+    operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
   }
 
   private void handleException(UUID operationId, BulkOperationDataProcessing dataProcessing, String message, Exception exception) {
@@ -785,6 +793,8 @@ public class BulkOperationService {
     operation.setErrorMessage(format(ERROR_MESSAGE_PATTERN, message, exception.getMessage()));
     operation.setStatus(OperationStatusType.FAILED);
     operation.setEndTime(LocalDateTime.now());
+    var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
+    operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
     bulkOperationRepository.save(operation);
   }
 

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -497,8 +497,8 @@ public class BulkOperationService {
         operation.setStatus(OperationStatusType.FAILED);
         operation.setEndTime(LocalDateTime.now());
         operation.setErrorMessage(e.getMessage());
-        var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
-        operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
+        var linkToCommittingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
+        operation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
       }
       executionRepository.save(execution);
     }
@@ -793,8 +793,8 @@ public class BulkOperationService {
     operation.setErrorMessage(format(ERROR_MESSAGE_PATTERN, message, exception.getMessage()));
     operation.setStatus(OperationStatusType.FAILED);
     operation.setEndTime(LocalDateTime.now());
-    var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
-    operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
+    var linkToCommittingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, operation.getErrorMessage());
+    operation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
     bulkOperationRepository.save(operation);
   }
 

--- a/src/main/java/org/folio/bulkops/service/DataExportJobUpdateService.java
+++ b/src/main/java/org/folio/bulkops/service/DataExportJobUpdateService.java
@@ -93,7 +93,7 @@ public class DataExportJobUpdateService {
         operation.setStatus(OperationStatusType.FAILED);
         operation.setEndTime(LocalDateTime.ofInstant(ofNullable(jobExecutionUpdate.getEndTime()).orElse(new Date()).toInstant(), UTC_ZONE));
         operation.setErrorMessage(isNull(jobExecutionUpdate.getErrorDetails()) ? EMPTY : jobExecutionUpdate.getErrorDetails());
-        var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(operation.getId(), ERROR_MATCHING_FILE_NAME_PREFIX, operation.getErrorMessage());
+        var linkToMatchingErrorsFile = errorService.uploadErrorsToStorage(operation.getId(), ERROR_MATCHING_FILE_NAME_PREFIX, operation.getErrorMessage());
         operation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
       }
     }
@@ -161,7 +161,7 @@ public class DataExportJobUpdateService {
         log.error(error, e);
         bulkOperation.setStatus(OperationStatusType.FAILED);
         bulkOperation.setErrorMessage(error);
-        var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_MATCHING_FILE_NAME_PREFIX, error + ":" + e.getMessage());
+        var linkToMatchingErrorsFile = errorService.uploadErrorsToStorage(bulkOperation.getId(), ERROR_MATCHING_FILE_NAME_PREFIX, error + ":" + e.getMessage());
         bulkOperation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
         throw new ServerErrorException("Error getting tenants list: " + e.getMessage());
       } finally {

--- a/src/main/java/org/folio/bulkops/service/ErrorService.java
+++ b/src/main/java/org/folio/bulkops/service/ErrorService.java
@@ -11,10 +11,10 @@ import static org.folio.bulkops.domain.dto.OperationStatusType.DATA_MODIFICATION
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEWED_NO_MARC_RECORDS;
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
 import static org.folio.bulkops.util.Constants.DATA_IMPORT_ERROR_DISCARDED;
-import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
+import static org.folio.bulkops.util.Constants.ERROR_FILE_NAME_ENDING;
 import static org.folio.bulkops.util.Constants.MSG_NO_ADMINISTRATIVE_CHANGE_REQUIRED;
-import static org.folio.bulkops.util.Constants.MSG_NO_MARC_CHANGE_REQUIRED;
 import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
+import static org.folio.bulkops.util.Constants.MSG_NO_MARC_CHANGE_REQUIRED;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -227,30 +227,31 @@ public class ErrorService {
       .type(content.getErrorType());
   }
 
-  public String uploadErrorsToStorage(UUID bulkOperationId) {
-    var contents = executionContentRepository.findByBulkOperationIdAndErrorMessageIsNotNullOrderByErrorType(bulkOperationId, OffsetRequest.of(0, Integer.MAX_VALUE));
-    if (!contents.isEmpty()) {
-      var errorsString = contents.stream()
-        .map(content -> String.join(Constants.COMMA_DELIMETER, content.getErrorType().getValue(), content.getIdentifier(), content.getErrorMessage()))
+  public String uploadErrorsToStorage(UUID bulkOperationId, String fileNamePrefix, String errorString) {
+    String errors;
+    if (errorString != null) {
+      errors = errorString;
+    } else {
+      var contents = executionContentRepository.findByBulkOperationIdAndErrorMessageIsNotNullOrderByErrorType(
+        bulkOperationId, OffsetRequest.of(0, Integer.MAX_VALUE));
+      if (contents.isEmpty()) {
+        return null;
+      }
+      errors = contents.stream()
+        .map(content -> String.join(Constants.COMMA_DELIMETER,
+          content.getErrorType().getValue(),
+          content.getIdentifier(),
+          content.getErrorMessage()))
         .collect(Collectors.joining(LF));
-      var errorsFileName = LocalDate.now() + operationRepository.findById(bulkOperationId)
-        .map(BulkOperation::getLinkToTriggeringCsvFile)
-        .map(FilenameUtils::getName)
-        .map(fileName -> ERROR_COMMITTING_FILE_NAME_PREFIX + fileName)
-        .orElse("-Errors.csv");
-      return remoteFileSystemClient.put(new ByteArrayInputStream(errorsString.getBytes()), bulkOperationId + "/" + errorsFileName);
     }
-    return null;
-  }
-
-  public String uploadErrorToStorage(UUID bulkOperationId, String fileNamePrefix, String errorString) {
     var errorsFileName = LocalDate.now() + operationRepository.findById(bulkOperationId)
       .map(BulkOperation::getLinkToTriggeringCsvFile)
       .map(FilenameUtils::getName)
       .map(fileName -> fileNamePrefix + fileName)
-      .orElse("-Errors.csv");
-    return remoteFileSystemClient.put(new ByteArrayInputStream(errorString.getBytes()), bulkOperationId + "/" + errorsFileName);
+      .orElse(ERROR_FILE_NAME_ENDING);
+    return remoteFileSystemClient.put(new ByteArrayInputStream(errors.getBytes()), bulkOperationId + "/" + errorsFileName);
   }
+
 
   public int getCommittedNumOfErrors(UUID bulkOperationId) {
     return executionContentRepository.countAllByBulkOperationIdAndErrorMessageIsNotNullAndErrorTypeIs(bulkOperationId, ErrorType.ERROR);

--- a/src/main/java/org/folio/bulkops/service/MarcUpdateService.java
+++ b/src/main/java/org/folio/bulkops/service/MarcUpdateService.java
@@ -4,6 +4,7 @@ import static java.util.Objects.nonNull;
 import static org.folio.bulkops.domain.dto.IdentifierType.HRID;
 import static org.folio.bulkops.domain.dto.OperationStatusType.APPLY_MARC_CHANGES;
 import static org.folio.bulkops.domain.dto.OperationStatusType.FAILED;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
 import static org.folio.bulkops.util.Constants.MARC;
 import static org.folio.bulkops.util.Constants.MSG_NO_MARC_CHANGE_REQUIRED;
 import static org.folio.bulkops.util.MarcHelper.fetchInstanceUuidOrElseHrid;
@@ -81,6 +82,8 @@ public class MarcUpdateService {
         bulkOperation.setStatus(FAILED);
         bulkOperation.setEndTime(LocalDateTime.now());
         bulkOperation.setErrorMessage(e.getMessage());
+        var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
+        bulkOperation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
         bulkOperationRepository.save(bulkOperation);
       }
       executionRepository.save(execution);

--- a/src/main/java/org/folio/bulkops/service/MarcUpdateService.java
+++ b/src/main/java/org/folio/bulkops/service/MarcUpdateService.java
@@ -82,8 +82,8 @@ public class MarcUpdateService {
         bulkOperation.setStatus(FAILED);
         bulkOperation.setEndTime(LocalDateTime.now());
         bulkOperation.setErrorMessage(e.getMessage());
-        var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
-        bulkOperation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
+        var linkToCommittingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
+        bulkOperation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
         bulkOperationRepository.save(bulkOperation);
       }
       executionRepository.save(execution);

--- a/src/main/java/org/folio/bulkops/service/MarcUpdateService.java
+++ b/src/main/java/org/folio/bulkops/service/MarcUpdateService.java
@@ -82,7 +82,7 @@ public class MarcUpdateService {
         bulkOperation.setStatus(FAILED);
         bulkOperation.setEndTime(LocalDateTime.now());
         bulkOperation.setErrorMessage(e.getMessage());
-        var linkToCommittingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
+        var linkToCommittingErrorsFile = errorService.uploadErrorsToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
         bulkOperation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
         bulkOperationRepository.save(bulkOperation);
       }

--- a/src/main/java/org/folio/bulkops/service/QueryService.java
+++ b/src/main/java/org/folio/bulkops/service/QueryService.java
@@ -80,7 +80,7 @@ public class QueryService {
     bulkOperation.setStatus(FAILED);
     bulkOperation.setErrorMessage(errorMessage);
     bulkOperation.setEndTime(LocalDateTime.now());
-    var linkToCommittingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
+    var linkToCommittingErrorsFile = errorService.uploadErrorsToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
     bulkOperation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
     return bulkOperationRepository.save(bulkOperation);
   }

--- a/src/main/java/org/folio/bulkops/service/QueryService.java
+++ b/src/main/java/org/folio/bulkops/service/QueryService.java
@@ -4,6 +4,7 @@ import static org.folio.bulkops.domain.dto.OperationStatusType.CANCELLED;
 import static org.folio.bulkops.domain.dto.OperationStatusType.FAILED;
 import static org.folio.bulkops.domain.dto.OperationStatusType.RETRIEVING_IDENTIFIERS;
 import static org.folio.bulkops.domain.dto.OperationStatusType.SAVED_IDENTIFIERS;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
 import static org.folio.bulkops.util.Constants.NEW_LINE_SEPARATOR;
 import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext;
 
@@ -18,7 +19,6 @@ import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -33,6 +33,7 @@ public class QueryService {
   private final QueryClient queryClient;
   private final BulkOperationRepository bulkOperationRepository;
   private final RemoteFileSystemClient remoteFileSystemClient;
+  private final ErrorService errorService;
 
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
@@ -79,6 +80,8 @@ public class QueryService {
     bulkOperation.setStatus(FAILED);
     bulkOperation.setErrorMessage(errorMessage);
     bulkOperation.setEndTime(LocalDateTime.now());
+    var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
+    bulkOperation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
     return bulkOperationRepository.save(bulkOperation);
   }
 

--- a/src/main/java/org/folio/bulkops/service/QueryService.java
+++ b/src/main/java/org/folio/bulkops/service/QueryService.java
@@ -80,8 +80,8 @@ public class QueryService {
     bulkOperation.setStatus(FAILED);
     bulkOperation.setErrorMessage(errorMessage);
     bulkOperation.setEndTime(LocalDateTime.now());
-    var linkToMatchingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
-    bulkOperation.setLinkToMatchedRecordsErrorsCsvFile(linkToMatchingErrorsFile);
+    var linkToCommittingErrorsFile = errorService.uploadErrorToStorage(bulkOperation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, bulkOperation.getErrorMessage());
+    bulkOperation.setLinkToCommittedRecordsErrorsCsvFile(linkToCommittingErrorsFile);
     return bulkOperationRepository.save(bulkOperation);
   }
 

--- a/src/main/java/org/folio/bulkops/service/SrsService.java
+++ b/src/main/java/org/folio/bulkops/service/SrsService.java
@@ -5,6 +5,7 @@ import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED;
 import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED_WITH_ERRORS;
 import static org.folio.bulkops.service.MarcUpdateService.CHANGED_MARC_CSV_PATH_TEMPLATE;
 import static org.folio.bulkops.service.MarcUpdateService.CHANGED_MARC_PATH_TEMPLATE;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
 
 import com.opencsv.CSVWriterBuilder;
 import lombok.RequiredArgsConstructor;
@@ -104,7 +105,7 @@ public class SrsService {
     operation.setTotalNumOfRecords(operation.getMatchedNumOfRecords());
     operation.setProcessedNumOfRecords(operation.getMatchedNumOfRecords());
     operation.setCommittedNumOfRecords(Math.max(committedNumOfRecords, getNumOfProcessedRecords(bulkOperation)));
-    operation.setLinkToCommittedRecordsErrorsCsvFile(errorService.uploadErrorsToStorage(operation.getId()));
+    operation.setLinkToCommittedRecordsErrorsCsvFile(errorService.uploadErrorsToStorage(operation.getId(), ERROR_COMMITTING_FILE_NAME_PREFIX, null));
     operation.setCommittedNumOfErrors(errorService.getCommittedNumOfErrors(operation.getId()));
     operation.setCommittedNumOfWarnings(errorService.getCommittedNumOfWarnings(operation.getId()));
     operation.setEndTime(LocalDateTime.now());

--- a/src/main/java/org/folio/bulkops/util/Constants.java
+++ b/src/main/java/org/folio/bulkops/util/Constants.java
@@ -79,4 +79,5 @@ public class Constants {
   public static final String FOLIO = "FOLIO";
   public static final String ERROR_COMMITTING_FILE_NAME_PREFIX = "-Committing-changes-Errors-";
   public static final String ERROR_MATCHING_FILE_NAME_PREFIX = "-Matching-Records-Errors-";
+  public static final String ERROR_FILE_NAME_ENDING = "-Errors.csv";
 }

--- a/src/main/java/org/folio/bulkops/util/Constants.java
+++ b/src/main/java/org/folio/bulkops/util/Constants.java
@@ -77,4 +77,6 @@ public class Constants {
 
   public static final String MARC = "MARC";
   public static final String FOLIO = "FOLIO";
+  public static final String ERROR_COMMITTING_FILE_NAME_PREFIX = "-Committing-changes-Errors-";
+  public static final String ERROR_MATCHING_FILE_NAME_PREFIX = "-Matching-Records-Errors-";
 }

--- a/src/test/java/org/folio/bulkops/processor/marc/MarcInstanceUpdateProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/marc/MarcInstanceUpdateProcessorTest.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED;
 import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED_WITH_ERRORS;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -151,7 +152,7 @@ class MarcInstanceUpdateProcessorTest extends BaseTest {
 
     marcInstanceUpdateProcessor.updateMarcRecords(bulkOperation);
 
-    verify(errorService).uploadErrorsToStorage(operationId);
+    verify(errorService).uploadErrorsToStorage(operationId, ERROR_COMMITTING_FILE_NAME_PREFIX, null);
 
     verify(bulkOperationRepository).save(bulkOperationCaptor.capture());
     assertThat(bulkOperationCaptor.getValue().getLinkToCommittedRecordsMarcFile()).isNull();

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -250,7 +250,7 @@ class BulkOperationServiceTest extends BaseTest {
     when(remoteFileSystemClient.put(any(), any()))
       .thenThrow(new S3ClientException("error"));
 
-    when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX,ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE + " : error"))
+    when(errorService.uploadErrorsToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX,ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE + " : error"))
       .thenReturn("/linkToMatchingErrorsFile.csv");
 
     bulkOperationService.uploadCsvFile(USER, IdentifierType.BARCODE, false, null, null, file);
@@ -350,7 +350,7 @@ class BulkOperationServiceTest extends BaseTest {
       .thenReturn(Job.builder().id(jobId).status(JobStatus.FAILED).build());
 
     if (jobStatus == JobStatus.FAILED) {
-      when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX, "File uploading failed - invalid job status: FAILED (expected: SCHEDULED)"))
+      when(errorService.uploadErrorsToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX, "File uploading failed - invalid job status: FAILED (expected: SCHEDULED)"))
         .thenReturn("/linkToMatchingErrorsFile.csv");
     }
 
@@ -388,7 +388,7 @@ class BulkOperationServiceTest extends BaseTest {
     when(bulkEditClient.uploadFile(eq(jobId), any(MultipartFile.class)))
       .thenThrow(new NotFoundException("Job was not found"));
 
-    when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX,FILE_UPLOADING_FAILED + " : Failed to upload file with identifiers: data export job was not found"))
+    when(errorService.uploadErrorsToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX,FILE_UPLOADING_FAILED + " : Failed to upload file with identifiers: data export job was not found"))
       .thenReturn("/linkToMatchingErrorsFile.csv");
 
     bulkOperationService.uploadCsvFile(USER, IdentifierType.BARCODE, false, null, null, file);
@@ -551,7 +551,7 @@ class BulkOperationServiceTest extends BaseTest {
       when(remoteFileSystemClient.get(pathToModified))
         .thenReturn(new FileInputStream(pathToUserJson));
 
-      when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_COMMITTING_FILE_NAME_PREFIX,ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE + " : error"))
+      when(errorService.uploadErrorsToStorage(bulkOperationId, ERROR_COMMITTING_FILE_NAME_PREFIX,ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE + " : error"))
         .thenReturn("/linkToCommittingErrorsFile.csv");
 
       bulkOperationService.startBulkOperation(bulkOperationId, UUID.randomUUID(), new BulkOperationStart().approach(ApproachType.IN_APP).step(EDIT));
@@ -845,7 +845,7 @@ class BulkOperationServiceTest extends BaseTest {
         .thenReturn(new FileInputStream(pathToInstanceMarc));
       when(remoteFileSystemClient.marcWriter(anyString())).thenThrow(new RuntimeException("error"));
       when(remoteFileSystemClient.writer(anyString())).thenReturn(new StringWriter());
-      when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_COMMITTING_FILE_NAME_PREFIX, "Confirm failed : error"))
+      when(errorService.uploadErrorsToStorage(bulkOperationId, ERROR_COMMITTING_FILE_NAME_PREFIX, "Confirm failed : error"))
         .thenReturn("/linkToCommittingErrorsFile.csv");
 
       bulkOperationService.startBulkOperation(bulkOperationId, UUID.randomUUID(), new BulkOperationStart().approach(ApproachType.IN_APP).step(EDIT));
@@ -1103,7 +1103,7 @@ class BulkOperationServiceTest extends BaseTest {
       when(remoteFileSystemClient.writer(pathToModifiedResult)).thenReturn(new RemoteStorageWriter(pathToModifiedResult, 8192, remoteFolioS3Client));
       when(remoteFileSystemClient.writer(pathToModifiedCsvResult)).thenReturn(new RemoteStorageWriter(pathToModifiedCsvResult, 8192, remoteFolioS3Client));
 
-      when(errorService.uploadErrorsToStorage(any(UUID.class))).thenReturn(linkToErrors);
+      when(errorService.uploadErrorsToStorage(any(UUID.class), any(String.class), any())).thenReturn(linkToErrors);
 
       bulkOperationService.startBulkOperation(bulkOperationId, UUID.randomUUID(), new BulkOperationStart().approach(ApproachType.IN_APP).step(COMMIT));
 

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -8,8 +8,6 @@ import static org.folio.bulkops.domain.dto.EntityType.ITEM;
 import static org.folio.bulkops.domain.dto.OperationStatusType.APPLY_MARC_CHANGES;
 import static org.folio.bulkops.domain.dto.OperationStatusType.EXECUTING_QUERY;
 import static org.folio.bulkops.domain.dto.OperationStatusType.SAVED_IDENTIFIERS;
-import static org.folio.bulkops.util.Constants.APPLY_TO_ITEMS;
-import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
 import static org.folio.bulkops.domain.dto.BulkOperationStep.COMMIT;
 import static org.folio.bulkops.domain.dto.BulkOperationStep.EDIT;
 import static org.folio.bulkops.domain.dto.EntityType.USER;
@@ -17,7 +15,14 @@ import static org.folio.bulkops.domain.dto.OperationStatusType.APPLY_CHANGES;
 import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED;
 import static org.folio.bulkops.domain.dto.OperationStatusType.DATA_MODIFICATION;
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
+import static org.folio.bulkops.service.BulkOperationService.FILE_UPLOADING_FAILED;
+import static org.folio.bulkops.util.Constants.APPLY_TO_ITEMS;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
+import static org.folio.bulkops.util.Constants.ERROR_MATCHING_FILE_NAME_PREFIX;
+import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
 import static org.folio.bulkops.util.ErrorCode.ERROR_MESSAGE_PATTERN;
+import static org.folio.bulkops.util.ErrorCode.ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE;
+import static org.folio.bulkops.util.ErrorCode.ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -113,7 +118,6 @@ import org.folio.bulkops.repository.BulkOperationDataProcessingRepository;
 import org.folio.bulkops.repository.BulkOperationExecutionContentRepository;
 import org.folio.bulkops.repository.BulkOperationExecutionRepository;
 import org.folio.bulkops.repository.BulkOperationRepository;
-import org.folio.bulkops.util.ErrorCode;
 import org.folio.bulkops.util.MarcCsvHelper;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.s3.client.RemoteStorageWriter;
@@ -238,15 +242,18 @@ class BulkOperationServiceTest extends BaseTest {
   void shouldPopulateErrorToBulkOperationIfS3IssuesForUploadIdentifiersInApp() {
     var file = new MockMultipartFile("file", "barcodes.csv", MediaType.TEXT_PLAIN_VALUE, new FileInputStream("src/test/resources/files/barcodes.csv").readAllBytes());
     var jobId = UUID.randomUUID();
+    var bulkOperationId = UUID.randomUUID();
 
     when(bulkOperationRepository.save(any(BulkOperation.class)))
-      .thenReturn(BulkOperation.builder().id(UUID.randomUUID()).build());
+      .thenReturn(BulkOperation.builder().id(bulkOperationId).build());
 
     when(remoteFileSystemClient.put(any(), any()))
       .thenThrow(new S3ClientException("error"));
 
-    var bulkOperation = bulkOperationService.uploadCsvFile(USER, IdentifierType.BARCODE, false, null, null, file);
-    var bulkOperationId = bulkOperation.getId();
+    when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX,ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE + " : error"))
+      .thenReturn("/linkToMatchingErrorsFile.csv");
+
+    bulkOperationService.uploadCsvFile(USER, IdentifierType.BARCODE, false, null, null, file);
 
     when(bulkOperationRepository.findById(bulkOperationId))
       .thenReturn(Optional.of(BulkOperation.builder().id(bulkOperationId).dataExportJobId(jobId).status(OperationStatusType.NEW).linkToTriggeringCsvFile("barcodes.csv").build()));
@@ -255,7 +262,8 @@ class BulkOperationServiceTest extends BaseTest {
     verify(bulkOperationRepository, times(2)).save(operationCaptor.capture());
     var capturedBulkOperation = operationCaptor.getValue();
     assertThat(capturedBulkOperation.getStatus(), equalTo(OperationStatusType.FAILED));
-    assertThat(capturedBulkOperation.getErrorMessage(),equalTo(format(ERROR_MESSAGE_PATTERN, ErrorCode.ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE, "error")));
+    assertThat(capturedBulkOperation.getErrorMessage(),equalTo(format(ERROR_MESSAGE_PATTERN, ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE, "error")));
+    assertThat(capturedBulkOperation.getLinkToMatchedRecordsErrorsCsvFile(), equalTo("/linkToMatchingErrorsFile.csv"));
   }
 
   @Test
@@ -309,7 +317,7 @@ class BulkOperationServiceTest extends BaseTest {
     verify(bulkOperationRepository, times(1)).save(operationCaptor.capture());
     var capturedBulkOperation = operationCaptor.getValue();
     assertThat(capturedBulkOperation.getStatus(), equalTo(OperationStatusType.FAILED));
-    assertThat(capturedBulkOperation.getErrorMessage(),equalTo(format(ERROR_MESSAGE_PATTERN, ErrorCode.ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE, "error")));
+    assertThat(capturedBulkOperation.getErrorMessage(),equalTo(format(ERROR_MESSAGE_PATTERN, ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE, "error")));
   }
 
   @Test
@@ -341,12 +349,20 @@ class BulkOperationServiceTest extends BaseTest {
     when(dataExportSpringClient.getJob(jobId))
       .thenReturn(Job.builder().id(jobId).status(JobStatus.FAILED).build());
 
+    if (jobStatus == JobStatus.FAILED) {
+      when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX, "File uploading failed - invalid job status: FAILED (expected: SCHEDULED)"))
+        .thenReturn("/linkToMatchingErrorsFile.csv");
+    }
+
     bulkOperationService.uploadCsvFile(USER, IdentifierType.BARCODE, false, null, null, file);
     bulkOperationService.startBulkOperation(bulkOperationId, any(UUID.class), new BulkOperationStart().approach(ApproachType.IN_APP).step(BulkOperationStep.UPLOAD));
 
     var operationCaptor = ArgumentCaptor.forClass(BulkOperation.class);
     verify(bulkOperationRepository, times(4)).save(operationCaptor.capture());
     assertEquals(OperationStatusType.FAILED, operationCaptor.getAllValues().get(3).getStatus());
+    if (jobStatus == JobStatus.FAILED) {
+      assertThat(operationCaptor.getValue().getLinkToMatchedRecordsErrorsCsvFile(), equalTo("/linkToMatchingErrorsFile.csv"));
+    }
   }
 
   @Test
@@ -372,12 +388,16 @@ class BulkOperationServiceTest extends BaseTest {
     when(bulkEditClient.uploadFile(eq(jobId), any(MultipartFile.class)))
       .thenThrow(new NotFoundException("Job was not found"));
 
+    when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_MATCHING_FILE_NAME_PREFIX,FILE_UPLOADING_FAILED + " : Failed to upload file with identifiers: data export job was not found"))
+      .thenReturn("/linkToMatchingErrorsFile.csv");
+
     bulkOperationService.uploadCsvFile(USER, IdentifierType.BARCODE, false, null, null, file);
     bulkOperationService.startBulkOperation(bulkOperationId, any(UUID.class), new BulkOperationStart().approach(ApproachType.IN_APP).step(BulkOperationStep.UPLOAD));
 
     var operationCaptor = ArgumentCaptor.forClass(BulkOperation.class);
     Awaitility.await().untilAsserted(() -> verify(bulkOperationRepository, times(4)).save(operationCaptor.capture()));
     assertEquals(OperationStatusType.FAILED, operationCaptor.getAllValues().get(3).getStatus());
+    assertThat(operationCaptor.getValue().getLinkToMatchedRecordsErrorsCsvFile(), equalTo("/linkToMatchingErrorsFile.csv"));
   }
 
   @ParameterizedTest
@@ -531,6 +551,9 @@ class BulkOperationServiceTest extends BaseTest {
       when(remoteFileSystemClient.get(pathToModified))
         .thenReturn(new FileInputStream(pathToUserJson));
 
+      when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_COMMITTING_FILE_NAME_PREFIX,ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE + " : error"))
+        .thenReturn("/linkToCommittingErrorsFile.csv");
+
       bulkOperationService.startBulkOperation(bulkOperationId, UUID.randomUUID(), new BulkOperationStart().approach(ApproachType.IN_APP).step(EDIT));
 
       var bulkOperationCaptor = ArgumentCaptor.forClass(BulkOperation.class);
@@ -538,7 +561,8 @@ class BulkOperationServiceTest extends BaseTest {
       var capturedBulkOperation = bulkOperationCaptor.getValue();
 
       assertThat(capturedBulkOperation.getStatus(), equalTo(OperationStatusType.FAILED));
-      assertThat(capturedBulkOperation.getErrorMessage(),equalTo(format(ERROR_MESSAGE_PATTERN, ErrorCode.ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE, "error")));
+      assertThat(capturedBulkOperation.getErrorMessage(),equalTo(format(ERROR_MESSAGE_PATTERN, ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE, "error")));
+      assertThat(capturedBulkOperation.getLinkToCommittedRecordsErrorsCsvFile(), equalTo("/linkToCommittingErrorsFile.csv"));
     }
   }
 
@@ -762,7 +786,7 @@ class BulkOperationServiceTest extends BaseTest {
       Awaitility.await().untilAsserted(() -> verify(bulkOperationRepository, atLeast(6)).save(bulkOperationCaptor.capture()));
       var capturedBulkOperation = bulkOperationCaptor.getValue();
       assertThat(capturedBulkOperation.getStatus(), equalTo(OperationStatusType.FAILED));
-      assertThat(capturedBulkOperation.getErrorMessage(),equalTo(format(ERROR_MESSAGE_PATTERN, ErrorCode.ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE, "error")));
+      assertThat(capturedBulkOperation.getErrorMessage(),equalTo(format(ERROR_MESSAGE_PATTERN, ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE, "error")));
     }
   }
 
@@ -821,6 +845,8 @@ class BulkOperationServiceTest extends BaseTest {
         .thenReturn(new FileInputStream(pathToInstanceMarc));
       when(remoteFileSystemClient.marcWriter(anyString())).thenThrow(new RuntimeException("error"));
       when(remoteFileSystemClient.writer(anyString())).thenReturn(new StringWriter());
+      when(errorService.uploadErrorToStorage(bulkOperationId, ERROR_COMMITTING_FILE_NAME_PREFIX, "Confirm failed : error"))
+        .thenReturn("/linkToCommittingErrorsFile.csv");
 
       bulkOperationService.startBulkOperation(bulkOperationId, UUID.randomUUID(), new BulkOperationStart().approach(ApproachType.IN_APP).step(EDIT));
 
@@ -828,6 +854,7 @@ class BulkOperationServiceTest extends BaseTest {
       Awaitility.await().untilAsserted(() -> verify(bulkOperationRepository, times(7)).save(bulkOperationCaptor.capture()));
       var capturedBulkOperation = bulkOperationCaptor.getValue();
       assertThat(capturedBulkOperation.getStatus(), equalTo(OperationStatusType.FAILED));
+      assertThat(capturedBulkOperation.getLinkToCommittedRecordsErrorsCsvFile(), equalTo("/linkToCommittingErrorsFile.csv"));
     }
   }
 

--- a/src/test/java/org/folio/bulkops/service/ErrorServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/ErrorServiceTest.java
@@ -9,6 +9,7 @@ import static org.folio.bulkops.service.ErrorService.IDENTIFIER;
 import static org.folio.bulkops.service.ErrorService.LINK;
 import static org.folio.bulkops.util.Constants.CSV_MSG_ERROR_TEMPLATE_OPTIMISTIC_LOCKING;
 import static org.folio.bulkops.util.Constants.DATA_IMPORT_ERROR_DISCARDED;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
 import static org.folio.bulkops.util.Constants.MSG_NO_ADMINISTRATIVE_CHANGE_REQUIRED;
 import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
 import static org.folio.bulkops.util.Constants.MSG_NO_MARC_CHANGE_REQUIRED;
@@ -145,7 +146,7 @@ class ErrorServiceTest extends BaseTest {
       var expectedFileName = bulkOperationId + "/" + LocalDate.now() + "-Committing-changes-Errors-records.csv";
       when(remoteFileSystemClient.put(any(), eq(expectedFileName))).thenReturn(expectedFileName);
 
-      var result = errorService.uploadErrorsToStorage(bulkOperationId);
+      var result = errorService.uploadErrorsToStorage(bulkOperationId, ERROR_COMMITTING_FILE_NAME_PREFIX, null);
       assertThat(result, equalTo(expectedFileName));
 
       var streamCaptor = ArgumentCaptor.forClass(InputStream.class);
@@ -490,7 +491,7 @@ class ErrorServiceTest extends BaseTest {
   @Test
   void uploadErrorsToStorageShouldReturnNullWhenContentsIsEmpty() {
     try (var context =  new FolioExecutionContextSetter(folioExecutionContext)) {
-      assertNull(errorService.uploadErrorsToStorage(bulkOperationId));
+      assertNull(errorService.uploadErrorsToStorage(bulkOperationId, ERROR_COMMITTING_FILE_NAME_PREFIX, null));
     }
   }
 

--- a/src/test/java/org/folio/bulkops/service/QueryServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/QueryServiceTest.java
@@ -78,6 +78,7 @@ class QueryServiceTest extends BaseTest {
 
     when(queryClient.getQuery(fqlQueryId)).thenReturn(new QueryDetails()
       .status(status)
+      .failureReason("some reason")
       .totalRecords(0));
 
     queryService.checkQueryExecutionStatus(operation);

--- a/src/test/java/org/folio/bulkops/service/SrsServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/SrsServiceTest.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED;
 import static org.folio.bulkops.domain.dto.OperationStatusType.COMPLETED_WITH_ERRORS;
+import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -76,7 +77,7 @@ class SrsServiceTest extends BaseTest {
       .thenReturn(objectMapper.readTree(Files.readString(Path.of("src/test/resources/files/srs_batch_response.json"))));
     when(bulkOperationRepository.findById(operationId))
       .thenReturn(Optional.of(operation));
-    when(errorService.uploadErrorsToStorage(operationId))
+    when(errorService.uploadErrorsToStorage(operationId, ERROR_COMMITTING_FILE_NAME_PREFIX, null))
       .thenReturn("errors.csv");
     when(errorService.getCommittedNumOfErrors(operationId))
       .thenReturn(numOfErrors);


### PR DESCRIPTION
[MODBULKOPS-377](https://folio-org.atlassian.net/browse/MODBULKOPS-377) - Create log with error message from another module

## Purpose
 If the bulk edit operations request to other modules succeeds (status is 200) but the other module fails to respond (due to some internal error) the bulk edit job fails but the details of what went wrong are not preserved because  Bulk edit log contains only a file with identifiers of records that were used to trigger the bulk edit job.

## Approach
Save error to a file and add the link to a bulk operation.

### TODOS and Open Questions

## Learning


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
