### PR TITLE
MODBULKSOPS-467 - Errors on Confirmation screen are increasing over time for bulk edit of MARC Instances due to reoccurring event of DI job completion

### DIFF
--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -724,21 +724,16 @@ public class BulkOperationService {
     };
   }
 
-  public void processDataImportResult(UUID dataImportJobProfileId) {
-    if (nonNull(dataImportJobProfileId)) {
-      bulkOperationRepository.findByDataImportJobProfileId(dataImportJobProfileId)
-        .ifPresent(bulkOperation -> {
-          var executions = metadataProviderService.getJobExecutions(bulkOperation.getDataImportJobProfileId());
-          updateBulkOperationBasedOnDataImportState(executions, bulkOperation);
-          if (metadataProviderService.isDataImportJobCompleted(executions)) {
-            executor.execute(getRunnableWithCurrentFolioContext(() -> {
-              var logEntries = metadataProviderService.getJobLogEntries(bulkOperation, executions);
-              errorService.saveErrorsFromDataImport(logEntries, bulkOperation);
-              var updatedIds = metadataProviderService.fetchUpdatedInstanceIds(logEntries);
-              srsService.retrieveMarcInstancesFromSrs(updatedIds, bulkOperation);
-            }));
-          }
-      });
+  public void processDataImportResult(BulkOperation bulkOperation) {
+    var executions = metadataProviderService.getJobExecutions(bulkOperation.getDataImportJobProfileId());
+    updateBulkOperationBasedOnDataImportState(executions, bulkOperation);
+    if (metadataProviderService.isDataImportJobCompleted(executions)) {
+      executor.execute(getRunnableWithCurrentFolioContext(() -> {
+        var logEntries = metadataProviderService.getJobLogEntries(bulkOperation, executions);
+        errorService.saveErrorsFromDataImport(logEntries, bulkOperation);
+        var updatedIds = metadataProviderService.fetchUpdatedInstanceIds(logEntries);
+        srsService.retrieveMarcInstancesFromSrs(updatedIds, bulkOperation);
+      }));
     }
   }
 

--- a/src/main/java/org/folio/bulkops/service/DataImportJobCompletionReceiverService.java
+++ b/src/main/java/org/folio/bulkops/service/DataImportJobCompletionReceiverService.java
@@ -2,7 +2,6 @@ package org.folio.bulkops.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.repository.BulkOperationRepository;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;

--- a/src/main/java/org/folio/bulkops/service/DataImportJobCompletionReceiverService.java
+++ b/src/main/java/org/folio/bulkops/service/DataImportJobCompletionReceiverService.java
@@ -2,6 +2,8 @@ package org.folio.bulkops.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.bulkops.domain.entity.BulkOperation;
+import org.folio.bulkops.repository.BulkOperationRepository;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
@@ -17,8 +19,8 @@ import java.util.Map;
 @Log4j2
 @RequiredArgsConstructor
 public class DataImportJobCompletionReceiverService {
-  private static final String BULK_OPERATION_DI_JOB_NAME_PREFIX = "Bulk operations data import job profile";
   private final BulkOperationService bulkOperationService;
+  private final BulkOperationRepository bulkOperationRepository;
   private final FolioModuleMetadata folioModuleMetadata;
   private final SystemUserScopedExecutionService executionService;
 
@@ -27,19 +29,24 @@ public class DataImportJobCompletionReceiverService {
     topicPattern = "${application.kafka.topic-pattern-di}",
     groupId = "${application.kafka.group-id}")
   public void receiveJobExecutionUpdate(DataImportJobExecution dataImportJobExecution, @Headers Map<String, Object> messageHeaders) {
+    log.info("Received event from DI: {}.", dataImportJobExecution);
+    try {
+      var importProfileId = dataImportJobExecution.getJobProfileInfo().getId();
+      bulkOperationRepository.findByDataImportJobProfileId(importProfileId).ifPresent(bulkOperation ->
+        processJobExecutionUpdate(bulkOperation, messageHeaders));
+    } catch (Exception e) {
+      log.error("Failed to process DI event: {}.", e.getMessage());
+    }
+  }
+
+  private void processJobExecutionUpdate(BulkOperation bulkOperation, Map<String, Object> messageHeaders) {
     var defaultFolioExecutionContext = DefaultFolioExecutionContext.fromMessageHeaders(folioModuleMetadata, messageHeaders);
     try (var context = new FolioExecutionContextSetter(defaultFolioExecutionContext)) {
-      log.info("Received event from DI: {}.", dataImportJobExecution);
-      if (dataImportJobExecution.getJobProfileInfo().getName().contains(BULK_OPERATION_DI_JOB_NAME_PREFIX)) {
-        var importProfileId = dataImportJobExecution.getJobProfileInfo().getId();
-        var tenantId = defaultFolioExecutionContext.getTenantId();
-        executionService.executeSystemUserScoped(tenantId, () -> {
-          bulkOperationService.processDataImportResult(importProfileId);
-          return null;
-        });
-      }
-    } catch (Exception e) {
-      log.error("Failed to process data import event: {}.", e.getMessage());
+      var tenantId = defaultFolioExecutionContext.getTenantId();
+      executionService.executeSystemUserScoped(tenantId, () -> {
+        bulkOperationService.processDataImportResult(bulkOperation);
+        return null;
+      });
     }
   }
 }

--- a/src/main/java/org/folio/bulkops/service/DataImportJobCompletionReceiverService.java
+++ b/src/main/java/org/folio/bulkops/service/DataImportJobCompletionReceiverService.java
@@ -38,6 +38,8 @@ public class DataImportJobCompletionReceiverService {
           return null;
         });
       }
+    } catch (Exception e) {
+      log.error("Failed to process data import event: {}.", e.getMessage());
     }
   }
 }

--- a/src/main/java/org/folio/bulkops/service/DataImportJobCompletionReceiverService.java
+++ b/src/main/java/org/folio/bulkops/service/DataImportJobCompletionReceiverService.java
@@ -40,7 +40,7 @@ public class DataImportJobCompletionReceiverService {
         });
       });
     } catch (Exception e) {
-      log.error("Failed to process DI event: {}.", e.getMessage());
+      log.error("Failed to process DI event: {}, reason: {}", dataImportJobExecution, e.getMessage());
     }
   }
 }

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -1680,23 +1680,23 @@ class BulkOperationServiceTest extends BaseTest {
       assertTrue(itemEntity.getDiscoverySuppress());
     }
   }
+
   @Test
   void shouldProcessDataImportResult() {
     try (var context =  new FolioExecutionContextSetter(folioExecutionContext)) {
       UUID dataImportJobProfileId = UUID.randomUUID();
-      BulkOperation operation = new BulkOperation();
-      operation.setId(UUID.randomUUID());
-      operation.setDataImportJobProfileId(dataImportJobProfileId);
+      BulkOperation operation = BulkOperation.builder()
+        .id(UUID.randomUUID())
+        .dataImportJobProfileId(dataImportJobProfileId)
+        .build();
 
-      when(bulkOperationRepository.findByDataImportJobProfileId(dataImportJobProfileId)).thenReturn(Optional.of(operation));
       when(metadataProviderService.getJobExecutions(dataImportJobProfileId)).thenReturn(List.of(new DataImportJobExecution().status(DataImportStatus.COMMITTED)));
       when(metadataProviderService.calculateProgress(any())).thenReturn(new DataImportProgress().current(10));
       when(metadataProviderService.isDataImportJobCompleted(any())).thenReturn(true);
       when(metadataProviderService.fetchUpdatedInstanceIds(any())).thenReturn(List.of(UUID.randomUUID().toString()));
 
-      bulkOperationService.processDataImportResult(dataImportJobProfileId);
+      bulkOperationService.processDataImportResult(operation);
 
-      verify(bulkOperationRepository).findByDataImportJobProfileId(dataImportJobProfileId);
       verify(metadataProviderService).getJobExecutions(dataImportJobProfileId);
       verify(metadataProviderService).calculateProgress(any());
       verify(metadataProviderService).isDataImportJobCompleted(any());

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -95,7 +95,9 @@ import org.folio.bulkops.domain.dto.BulkOperationRuleCollection;
 import org.folio.bulkops.domain.dto.BulkOperationRuleRuleDetails;
 import org.folio.bulkops.domain.dto.BulkOperationStart;
 import org.folio.bulkops.domain.dto.BulkOperationStep;
+import org.folio.bulkops.domain.dto.DataImportJobExecution;
 import org.folio.bulkops.domain.dto.DataImportProgress;
+import org.folio.bulkops.domain.dto.DataImportStatus;
 import org.folio.bulkops.domain.dto.EntityType;
 import org.folio.bulkops.domain.dto.ErrorType;
 import org.folio.bulkops.domain.dto.IdentifierType;
@@ -1687,7 +1689,7 @@ class BulkOperationServiceTest extends BaseTest {
       operation.setDataImportJobProfileId(dataImportJobProfileId);
 
       when(bulkOperationRepository.findByDataImportJobProfileId(dataImportJobProfileId)).thenReturn(Optional.of(operation));
-      when(metadataProviderService.getJobExecutions(dataImportJobProfileId)).thenReturn(List.of(new org.folio.bulkops.domain.dto.DataImportJobExecution()));
+      when(metadataProviderService.getJobExecutions(dataImportJobProfileId)).thenReturn(List.of(new DataImportJobExecution().status(DataImportStatus.COMMITTED)));
       when(metadataProviderService.calculateProgress(any())).thenReturn(new DataImportProgress().current(10));
       when(metadataProviderService.isDataImportJobCompleted(any())).thenReturn(true);
       when(metadataProviderService.fetchUpdatedInstanceIds(any())).thenReturn(List.of(UUID.randomUUID().toString()));

--- a/src/test/java/org/folio/bulkops/service/DataImportJobCompletionReceiverServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/DataImportJobCompletionReceiverServiceTest.java
@@ -4,18 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import lombok.SneakyThrows;
 import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.configs.kafka.dto.Event;
+import org.folio.bulkops.domain.entity.BulkOperation;
+import org.folio.bulkops.repository.BulkOperationRepository;
 import org.folio.spring.model.SystemUser;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.folio.spring.service.SystemUserService;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 class DataImportJobCompletionReceiverServiceTest extends BaseTest {
@@ -36,38 +37,50 @@ class DataImportJobCompletionReceiverServiceTest extends BaseTest {
   @MockBean
   private SystemUserService systemUserService;
 
+  @MockBean
+  private BulkOperationRepository bulkOperationRepository;
+
   @Test
   void testReceiveJobExecutionUpdate() throws IOException {
+    var jobProfileId = UUID.fromString("e34d7b92-9b83-11eb-a8b3-0242ac130003");
+    var bulkOperation = BulkOperation.builder().id(UUID.randomUUID()).build();
     try (var context = new FolioExecutionContextSetter(folioExecutionContext)) {
+      when(bulkOperationRepository.findByDataImportJobProfileId(jobProfileId))
+        .thenReturn(Optional.of(bulkOperation));
       when(systemUserService.getAuthedSystemUser(any())).thenReturn(new SystemUser("mod-bulk-operation", "http://okapi:9130", "diku", null, ""));
       var message = Files.readString(Path.of("src/test/resources/files/kafka/data_import_job_completed_message.json"));
       var event = OBJECT_MAPPER.readValue(message, Event.class);
       var payload = OBJECT_MAPPER.readValue(event.getEventPayload(), org.folio.bulkops.domain.dto.DataImportJobExecution.class);
       receiverService.receiveJobExecutionUpdate(payload, Map.of());
-      var dataImportJobProfileIdCaptor = ArgumentCaptor.forClass(UUID.class);
-      verify(bulkOperationService, times(1)).processDataImportResult(dataImportJobProfileIdCaptor.capture());
+      verify(bulkOperationService).processDataImportResult(bulkOperation);
     }
   }
 
   @Test
   void shouldIgnoreNonBulkOperationJobExecutionUpdate() throws IOException {
     try (var context = new FolioExecutionContextSetter(folioExecutionContext)) {
+      when(bulkOperationRepository.findByDataImportJobProfileId(any(UUID.class))).thenReturn(Optional.empty());
       when(systemUserService.getAuthedSystemUser(any())).thenReturn(new SystemUser("mod-bulk-operation", "http://okapi:9130", "diku", null, ""));
       var message = Files.readString(Path.of("src/test/resources/files/kafka/data_import_job_completed_non_bulk_edit_message.json"));
       var event = OBJECT_MAPPER.readValue(message, Event.class);
       var payload = OBJECT_MAPPER.readValue(event.getEventPayload(), org.folio.bulkops.domain.dto.DataImportJobExecution.class);
+
       receiverService.receiveJobExecutionUpdate(payload, Map.of());
-      var dataImportJobProfileIdCaptor = ArgumentCaptor.forClass(UUID.class);
-      verify(bulkOperationService, never()).processDataImportResult(dataImportJobProfileIdCaptor.capture());
+
+      verify(bulkOperationService, never()).processDataImportResult(any(BulkOperation.class));
     }
   }
 
   @Test
   @SneakyThrows
   void shouldHandleExceptionDuringMessageProcessing() {
+    var jobProfileId = UUID.fromString("e34d7b92-9b83-11eb-a8b3-0242ac130003");
+    var bulkOperation = BulkOperation.builder().id(UUID.randomUUID()).build();
     try (var context = new FolioExecutionContextSetter(folioExecutionContext)) {
+      when(bulkOperationRepository.findByDataImportJobProfileId(jobProfileId))
+        .thenReturn(Optional.of(bulkOperation));
       when(systemUserService.getAuthedSystemUser(any())).thenReturn(new SystemUser("mod-bulk-operation", "http://okapi:9130", "diku", null, ""));
-      doThrow(new RuntimeException("Processing exception")).when(bulkOperationService).processDataImportResult(any(UUID.class));
+      doThrow(new RuntimeException("Processing exception")).when(bulkOperationService).processDataImportResult(bulkOperation);
       var message = Files.readString(Path.of("src/test/resources/files/kafka/data_import_job_completed_message.json"));
       var event = OBJECT_MAPPER.readValue(message, Event.class);
       var payload = OBJECT_MAPPER.readValue(event.getEventPayload(), org.folio.bulkops.domain.dto.DataImportJobExecution.class);


### PR DESCRIPTION
[MODBULKSOPS-467](https://folio-org.atlassian.net/browse/MODBULKOPS-467) - Errors on Confirmation screen are increasing over time for bulk edit of MARC Instances due to reoccurring event of DI job completion

## Purpose
environment the following behavior noticed: the number of errors on Confirmation screen and in file with Committing-Changes-Errors increased over time. This happened because event of DI job completion continued to come many times, and each time after that bulk edit asked for one more portion of errors from DI

## Approach
* Added exception handler
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
