### PR TITLE
MODBULKOPS-454 - Issue with data-import.splitconfig.get (adding Eureka-specific configuration)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -629,6 +629,19 @@
       "version": "1.1"
     }
   ],
+  "metadata": {
+    "user": {
+      "type": "system",
+      "permissions": [
+        "users.collection.get",
+        "data-import.splitconfig.get",
+        "metadata-provider.jobExecutions.collection.get",
+        "metadata-provider.jobLogEntries.collection.get",
+        "source-storage.parsed-records.fetch.collection.post",
+        "inventory-storage.contributor-types.collection.get"
+      ]
+    }
+  },
   "launchDescriptor": {
     "dockerImage": "@artifactId@:@version@",
     "dockerPull": false,


### PR DESCRIPTION
Follow-up PR to [PR#354](https://github.com/folio-org/mod-bulk-operations/pull/354) with missed configuration for Eureka platform.