### PR TITLE
MODBULKOPS-501 - First user UUID record from .csv file with "UTF-8 with BOM" encoding is processed as error in Bulk edit (Identifier > Users > User UUIDs)

### DIFF
--- a/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
+++ b/src/main/java/org/folio/bulkops/controller/BulkOperationController.java
@@ -13,6 +13,7 @@ import static org.folio.bulkops.domain.dto.FileContentType.TRIGGERING_FILE;
 import static org.folio.bulkops.util.Constants.CSV_EXTENSION;
 import static org.folio.bulkops.util.Constants.NON_PRINTING_DELIMITER;
 import static org.folio.bulkops.util.Constants.SPLIT_NOTE_ENTITIES;
+import static org.folio.bulkops.util.Constants.UTF_8_BOM;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -72,8 +73,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Log4j2
 public class BulkOperationController implements BulkOperationsApi {
-
-  private final byte[] utf8Bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
 
   private final BulkOperationService bulkOperationService;
   private final PreviewService previewService;
@@ -210,9 +209,9 @@ public class BulkOperationController implements BulkOperationsApi {
   }
 
   private byte[] getCsvContentWithUtf8Bom(byte[] content) {
-    var contentCharsByUtf8BomLen = Arrays.copyOfRange(content, 0, utf8Bom.length);
-    if (!Arrays.equals(utf8Bom, contentCharsByUtf8BomLen)) {
-      return ArrayUtils.addAll(utf8Bom, content);
+    var contentCharsByUtf8BomLen = Arrays.copyOfRange(content, 0, UTF_8_BOM.length);
+    if (!Arrays.equals(UTF_8_BOM, contentCharsByUtf8BomLen)) {
+      return ArrayUtils.addAll(UTF_8_BOM, content);
     }
     return content;
   }

--- a/src/main/java/org/folio/bulkops/processor/marc/MarcFlowCommitProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/marc/MarcFlowCommitProcessor.java
@@ -88,8 +88,6 @@ public class MarcFlowCommitProcessor implements CommitProcessor {
             remoteFileSystemClient.get(bulkOperation.getLinkToCommittedRecordsCsvFile()),
             new ByteArrayInputStream(appendedCsvRecords.getBytes()));
           remoteFileSystemClient.put(appendedCsvStream, committedCsvFileName);
-          remoteFileSystemClient.remove(bulkOperation.getLinkToCommittedRecordsCsvFile());
-          bulkOperation.setLinkToCommittedRecordsCsvFile(committedCsvFileName);
         }
         if (nonNull(bulkOperation.getLinkToCommittedRecordsCsvFile())) {
           remoteFileSystemClient.remove(bulkOperation.getLinkToCommittedRecordsCsvFile());

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -724,6 +724,7 @@ public class BulkOperationService {
         // while commit is in progress, no download links should be available
         updatedOperation.setLinkToCommittedRecordsCsvFile(null);
         updatedOperation.setLinkToCommittedRecordsErrorsCsvFile(null);
+        updatedOperation.setLinkToCommittedRecordsMarcFile(null);
         yield updatedOperation;
       }
       default -> operation;

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -51,6 +51,7 @@ import java.util.concurrent.Executors;
 
 import com.opencsv.CSVWriterBuilder;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.bulkops.client.BulkEditClient;
 import org.folio.bulkops.client.DataExportSpringClient;
@@ -198,7 +199,8 @@ public class BulkOperationService {
         operation.setMatchedNumOfRecords(numOfLines);
         operation.setApproach(MANUAL);
       } else {
-        var linkToTriggeringFile = remoteFileSystemClient.put(multipartFile.getInputStream(), operation.getId() + "/" + multipartFile.getOriginalFilename());
+        var bomInputStream = BOMInputStream.builder().setInputStream(multipartFile.getInputStream()).get();
+        var linkToTriggeringFile = remoteFileSystemClient.put(bomInputStream, operation.getId() + "/" + multipartFile.getOriginalFilename());
         operation.setLinkToTriggeringCsvFile(linkToTriggeringFile);
       }
     } catch (S3ClientException e) {

--- a/src/main/java/org/folio/bulkops/service/BulkOperationService.java
+++ b/src/main/java/org/folio/bulkops/service/BulkOperationService.java
@@ -238,8 +238,6 @@ public class BulkOperationService {
     var modifiedJsonFileName = String.format(PREVIEW_JSON_PATH_TEMPLATE, operationId, LocalDate.now(), triggeringFileName);
     var modifiedPreviewCsvFileName = String.format(PREVIEW_CSV_PATH_TEMPLATE, operationId, LocalDate.now(), triggeringFileName);
 
-    prepareMatchedJsonForInstanceMarc(operation, dataProcessing);
-
     try (var readerForMatchedJsonFile = remoteFileSystemClient.get(operation.getLinkToMatchedRecordsJsonFile());
          var writerForModifiedPreviewCsvFile = remoteFileSystemClient.writer(modifiedPreviewCsvFileName);
          var writerForModifiedJsonFile = remoteFileSystemClient.writer(modifiedJsonFileName)) {
@@ -252,6 +250,13 @@ public class BulkOperationService {
 
       while (iterator.hasNext()) {
         var original = iterator.next();
+        if (INSTANCE_MARC.equals(operation.getEntityType()) && original instanceof ExtendedInstance extendedInstance
+          && !MARC.equals(extendedInstance.getEntity().getSource())) {
+          var instance = extendedInstance.getEntity();
+          var identifier = HRID.equals(operation.getIdentifierType()) ? instance.getHrid() : instance.getId();
+          errorService.saveError(operation.getId(), identifier, MSG_BULK_EDIT_SUPPORTED_FOR_MARC_ONLY.formatted(instance.getSource()), ErrorType.ERROR);
+          continue;
+        }
         var modified = processUpdate(original, operation, ruleCollection, extendedClazz);
         List<BulkOperationExecutionContent> bulkOperationExecutionContents = new ArrayList<>();
         if (Objects.nonNull(modified)) {
@@ -289,38 +294,6 @@ public class BulkOperationService {
     } finally {
       dataProcessingRepository.save(dataProcessing);
       handleProcessingCompletion(operationId);
-    }
-  }
-
-  private void prepareMatchedJsonForInstanceMarc(BulkOperation bulkOperation, BulkOperationDataProcessing dataProcessing) {
-    if (INSTANCE_MARC.equals(bulkOperation.getEntityType())) {
-      var matchedJsonFileName = bulkOperation.getLinkToMatchedRecordsJsonFile();
-      var tmpMatchedJsonFileName = TMP_MATCHED_JSON_PATH_TEMPLATE.formatted(bulkOperation.getId());
-      remoteFileSystemClient.put(remoteFileSystemClient.get(matchedJsonFileName), tmpMatchedJsonFileName);
-      remoteFileSystemClient.remove(matchedJsonFileName);
-      try (var readerForMatchedJsonFile = remoteFileSystemClient.get(tmpMatchedJsonFileName);
-           var writerForMatchedJsonFile = remoteFileSystemClient.writer(matchedJsonFileName)) {
-        var iterator = objectMapper.readValues(new JsonFactory().createParser(readerForMatchedJsonFile), ExtendedInstance.class);
-        while (iterator.hasNext()) {
-          var original = iterator.next();
-          if (original instanceof ExtendedInstance extendedInstance) {
-            if (!MARC.equals(extendedInstance.getEntity().getSource())) {
-              var instance = extendedInstance.getEntity();
-              var identifier = HRID.equals(bulkOperation.getIdentifierType()) ? instance.getHrid() : instance.getId();
-              errorService.saveError(bulkOperation.getId(), identifier, MSG_BULK_EDIT_SUPPORTED_FOR_MARC_ONLY.formatted(instance.getSource()), ErrorType.ERROR);
-            } else {
-              var originalRecord = objectMapper.writeValueAsString(original) + LF;
-              writerForMatchedJsonFile.write(originalRecord);
-            }
-          }
-        }
-      } catch (S3ClientException e) {
-        handleException(bulkOperation.getId(), dataProcessing, ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE, e);
-      } catch (Exception e) {
-        handleException(bulkOperation.getId(), dataProcessing, MSG_CONFIRM_FAILED, e);
-      } finally {
-        remoteFileSystemClient.remove(tmpMatchedJsonFileName);
-      }
     }
   }
 
@@ -470,6 +443,10 @@ public class BulkOperationService {
 
         while (hasNextRecord(originalFileIterator, modifiedFileIterator)) {
           var original = originalFileIterator.next();
+          if (INSTANCE_MARC.equals(operation.getEntityType()) && original instanceof ExtendedInstance extendedInstance
+            && !MARC.equals(extendedInstance.getEntity().getSource())) {
+            continue;
+          }
           var modified = modifiedFileIterator.next();
           List<BulkOperationExecutionContent> bulkOperationExecutionContents = new ArrayList<>();
 

--- a/src/main/java/org/folio/bulkops/util/Constants.java
+++ b/src/main/java/org/folio/bulkops/util/Constants.java
@@ -84,4 +84,6 @@ public class Constants {
   public static final String CHANGED_CSV_PATH_TEMPLATE = "%s/%s-Changed-Records-CSV-%s.csv";
   public static final String CHANGED_MARC_PATH_TEMPLATE = "%s/%s-Changed-Records-MARC-%s.mrc";
   public static final String CHANGED_MARC_CSV_PATH_TEMPLATE = "%s/%s-Changed-Records-MARC-CSV-%s.csv";
+
+  public static final byte[] UTF_8_BOM = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
 }

--- a/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/BulkOperationServiceTest.java
@@ -22,11 +22,13 @@ import static org.folio.bulkops.util.Constants.APPLY_TO_ITEMS;
 import static org.folio.bulkops.util.Constants.ERROR_COMMITTING_FILE_NAME_PREFIX;
 import static org.folio.bulkops.util.Constants.ERROR_MATCHING_FILE_NAME_PREFIX;
 import static org.folio.bulkops.util.Constants.MSG_NO_CHANGE_REQUIRED;
+import static org.folio.bulkops.util.Constants.UTF_8_BOM;
 import static org.folio.bulkops.util.ErrorCode.ERROR_MESSAGE_PATTERN;
 import static org.folio.bulkops.util.ErrorCode.ERROR_NOT_CONFIRM_CHANGES_S3_ISSUE;
 import static org.folio.bulkops.util.ErrorCode.ERROR_UPLOAD_IDENTIFIERS_S3_ISSUE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,11 +55,13 @@ import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -1851,5 +1855,22 @@ class BulkOperationServiceTest extends BaseTest {
     if (hasMarcRules) {
       verify(marcUpdateService).commitForInstanceMarc(any(BulkOperation.class));
     }
+  }
+
+  @Test
+  @SneakyThrows
+  void shouldRemoveBOMOnFileUpload() {
+    var inputStream = new SequenceInputStream(new ByteArrayInputStream(UTF_8_BOM), new ByteArrayInputStream("abc".getBytes()));
+    var file = new MockMultipartFile("file", "uuids.csv", MediaType.TEXT_PLAIN_VALUE, inputStream);
+    var contentCaptor = ArgumentCaptor.forClass(InputStream.class);
+
+    when(bulkOperationRepository.save(any(BulkOperation.class)))
+      .thenReturn(new BulkOperation());
+
+    bulkOperationService.uploadCsvFile(USER, IdentifierType.ID, false, null, null, file);
+
+    verify(remoteFileSystemClient).put(contentCaptor.capture(), anyString());
+    var contentCharsByUtf8BomLen = Arrays.copyOfRange(contentCaptor.getValue().readAllBytes(), 0, UTF_8_BOM.length);
+    assertFalse(Arrays.equals(UTF_8_BOM, contentCharsByUtf8BomLen));
   }
 }


### PR DESCRIPTION
[MODBULKOPS-501](https://folio-org.atlassian.net/browse/MODBULKOPS-501) - First user UUID record from .csv file with "UTF-8 with BOM" encoding is processed as error in Bulk edit (Identifier > Users > User UUIDs)

## Purpose
When uploading a .csv file containing User UUIDs with "UTF-8 with BOM" encoding, the first record from the file is processed as error with “No match found“ reason.

## Approach
* Fixed file uploading logic
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
