### PR TITLE
Adding missed permission inventory-storage.instance-note-types.collection.get

### DIFF
--- a/src/main/resources/permissions/system-user-permissions.csv
+++ b/src/main/resources/permissions/system-user-permissions.csv
@@ -4,3 +4,4 @@ metadata-provider.jobLogEntries.collection.get
 source-storage.parsed-records.fetch.collection.post
 users.collection.get
 inventory-storage.contributor-types.collection.get
+inventory-storage.instance-note-types.collection.get


### PR DESCRIPTION
Adding missed permission inventory-storage.instance-note-types.collection.get to system user. Technical PR similar to [PR#399](https://github.com/folio-org/mod-bulk-operations/pull/399). This PR is needed to solve Jenkins issue.