### PR TITLE
MODBULKOPS-520 - Error after "Run Query" when the UI is set to a language other than English

### DIFF
--- a/src/main/java/org/folio/bulkops/service/EntityTypeService.java
+++ b/src/main/java/org/folio/bulkops/service/EntityTypeService.java
@@ -1,11 +1,16 @@
 package org.folio.bulkops.service;
 
+import static org.folio.bulkops.util.Constants.HOLDINGS_ENTITY_TYPE_ID;
+import static org.folio.bulkops.util.Constants.INSTANCE_ENTITY_TYPE_ID;
+import static org.folio.bulkops.util.Constants.ITEM_ENTITY_TYPE_ID;
+import static org.folio.bulkops.util.Constants.USER_ENTITY_TYPE_ID;
+
+import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import org.folio.bulkops.client.EntityTypeClient;
 import org.folio.bulkops.domain.dto.EntityType;
 import org.springframework.stereotype.Service;
-
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -13,13 +18,24 @@ public class EntityTypeService {
   private final EntityTypeClient entityTypeClient;
 
   public EntityType getEntityTypeById(UUID entityTypeId) {
+    var id = entityTypeClient.getEntityType(entityTypeId).getId();
     var alias = entityTypeClient.getEntityType(entityTypeId).getLabelAlias();
     return switch (alias) {
       case "Items" -> EntityType.ITEM;
       case "Users" -> EntityType.USER;
       case "Holdings" -> EntityType.HOLDINGS_RECORD;
       case "Instances" -> EntityType.INSTANCE;
-      default -> throw new IllegalArgumentException(String.format("Entity type %s is not supported", alias));
+      default -> getAliasOrId(id, alias);
+    };
+  }
+
+  private EntityType getAliasOrId(String id, String alias) {
+    return switch (id) {
+      case ITEM_ENTITY_TYPE_ID -> EntityType.ITEM;
+      case USER_ENTITY_TYPE_ID -> EntityType.USER;
+      case HOLDINGS_ENTITY_TYPE_ID -> EntityType.HOLDINGS_RECORD;
+      case INSTANCE_ENTITY_TYPE_ID -> EntityType.INSTANCE;
+      default -> throw new IllegalArgumentException(String.format("Entity type id=%s and alias=%s is not supported", id, alias));
     };
   }
 }

--- a/src/main/java/org/folio/bulkops/util/Constants.java
+++ b/src/main/java/org/folio/bulkops/util/Constants.java
@@ -108,4 +108,9 @@ public class Constants {
   public static final String MATCHED_RECORDS_FILE_TEMPLATE = "%s/%s%s-%s-Records-%s.%s";
 
   public static final byte[] UTF_8_BOM = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+
+  public static final String ITEM_ENTITY_TYPE_ID = "d0213d22-32cf-490f-9196-d81c3c66e53f";
+  public static final String USER_ENTITY_TYPE_ID = "ddc93926-d15a-4a45-9d9c-93eadc3d9bbf";
+  public static final String HOLDINGS_ENTITY_TYPE_ID = "8418e512-feac-4a6a-a56d-9006aab31e33";
+  public static final String INSTANCE_ENTITY_TYPE_ID = "6b08439b-4f8e-4468-8046-ea620f5cfb74";
 }

--- a/src/test/java/org/folio/bulkops/service/EntityTypeServiceTest.java
+++ b/src/test/java/org/folio/bulkops/service/EntityTypeServiceTest.java
@@ -3,6 +3,8 @@ package org.folio.bulkops.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
+import java.util.UUID;
+
 import org.folio.bulkops.client.EntityTypeClient;
 import org.folio.querytool.domain.dto.EntityType;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,8 +13,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.UUID;
 
 @ExtendWith(MockitoExtension.class)
 class EntityTypeServiceTest {
@@ -23,11 +23,18 @@ class EntityTypeServiceTest {
 
   @ParameterizedTest
   @CsvSource(textBlock = """
-    ae6a4972-0e0d-4069-9936-99ba6e91658d  | Users | USER
-    a5f253dc-3215-46bb-9714-2b26d8b3b613  | Items | ITEM
+    ae6a4972-0e0d-4069-9936-99ba6e91658d | Users | USER
+    a5f253dc-3215-46bb-9714-2b26d8b3b613 | Items | ITEM
+    65f253dc-3215-46bb-9714-2b26d8b3b613 | Holdings | HOLDINGS_RECORD
+    75f253dc-3215-46bb-9714-2b26d8b3b613 | Instances | INSTANCE
+    d0213d22-32cf-490f-9196-d81c3c66e53f | ItemFr | ITEM
+    ddc93926-d15a-4a45-9d9c-93eadc3d9bbf | UserFr | USER
+    8418e512-feac-4a6a-a56d-9006aab31e33 | HoldFr | HOLDINGS_RECORD
+    6b08439b-4f8e-4468-8046-ea620f5cfb74 | InstFr | INSTANCE
     """, delimiter = '|')
   void testGetEntityType(UUID entityTypeId, String alias, org.folio.bulkops.domain.dto.EntityType expectedType) {
-    when(entityTypeClient.getEntityType(entityTypeId)).thenReturn(new EntityType().labelAlias(alias));
+    when(entityTypeClient.getEntityType(entityTypeId)).thenReturn(new EntityType().labelAlias(alias)
+            .id(entityTypeId.toString()));
 
     var actualType = entityTypeService.getEntityTypeById(entityTypeId);
 


### PR DESCRIPTION
[MODBULKOPS-520](https://folio-org.atlassian.net/browse/MODBULKOPS-520) - Error after "Run Query" when the UI is set to a language other than English

## Purpose
Add hard coded entity type ids if alias is in other than English.

## Approach
Update EntityTypeService.

### TODOS and Open Questions

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
