### PR TITLE
MODBULKOPS-551 - Missing data retrieving optimization (roll-back items client)

### DIFF
--- a/src/main/java/org/folio/bulkops/batch/jobs/BulkEditItemProcessor.java
+++ b/src/main/java/org/folio/bulkops/batch/jobs/BulkEditItemProcessor.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.bulkops.batch.jobs.processidentifiers.DuplicationCheckerFactory;
-import org.folio.bulkops.client.ItemStorageClient;
+import org.folio.bulkops.client.ItemClient;
 import org.folio.bulkops.client.SearchClient;
 import org.folio.bulkops.client.UserClient;
 import org.folio.bulkops.domain.bean.ExtendedItem;
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Log4j2
 public class BulkEditItemProcessor implements ItemProcessor<ItemIdentifier, ExtendedItemCollection>, EntityExtractor {
-  private final ItemStorageClient itemStorageClient;
+  private final ItemClient itemClient;
   private final ConsortiaService consortiaService;
   private final SearchClient searchClient;
   private final UserClient userClient;
@@ -105,7 +105,7 @@ public class BulkEditItemProcessor implements ItemProcessor<ItemIdentifier, Exte
           affiliatedPermittedTenants.forEach(tenantId -> {
             try (var context = new FolioExecutionContextSetter(FolioExecutionContextUtil.prepareContextForTenant(tenantId, folioModuleMetadata, folioExecutionContext))) {
               var url = getMatchPattern(identifierType).formatted(idType, identifier);
-              var itemCollection = itemStorageClient.getByQuery(url, Integer.MAX_VALUE);
+              var itemCollection = itemClient.getByQuery(url, Integer.MAX_VALUE);
               if (itemCollection.getItems().size() > limit) {
                 log.error("Central tenant case: response from {} for tenant {}: {}", url, tenantId, getResponseAsString(itemCollection));
                 throw new BulkEditException(MULTIPLE_MATCHES_MESSAGE, ErrorType.ERROR);
@@ -133,7 +133,7 @@ public class BulkEditItemProcessor implements ItemProcessor<ItemIdentifier, Exte
         checkReadPermissions(folioExecutionContext.getTenantId(), identifier);
         var query = getMatchPattern(identifierType).formatted(idType, identifier);
         var currentTenantId = folioExecutionContext.getTenantId();
-        var itemCollection =  itemStorageClient.getByQuery(query, Integer.MAX_VALUE);
+        var itemCollection =  itemClient.getByQuery(query, Integer.MAX_VALUE);
         if (itemCollection.getItems().size() > limit) {
           log.error("Member/local tenant case: response from {} for tenant {}: {}", query, currentTenantId, getResponseAsString(itemCollection));
           throw new BulkEditException(MULTIPLE_MATCHES_MESSAGE, ErrorType.ERROR);

--- a/src/test/java/org/folio/bulkops/batch/jobs/BulkEditItemProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/batch/jobs/BulkEditItemProcessorTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 
 import org.folio.bulkops.batch.jobs.processidentifiers.DuplicationCheckerFactory;
-import org.folio.bulkops.client.ItemStorageClient;
+import org.folio.bulkops.client.ItemClient;
 import org.folio.bulkops.domain.bean.ElectronicAccess;
 import org.folio.bulkops.domain.bean.ExtendedItemCollection;
 import org.folio.bulkops.domain.bean.Item;
@@ -55,7 +55,7 @@ import java.util.UUID;
 class BulkEditItemProcessorTest {
 
   @Mock
-  private ItemStorageClient itemStorageClient;
+  private ItemClient itemClient;
   @Mock
   private ConsortiaService consortiaService;
   @Mock
@@ -110,7 +110,7 @@ class BulkEditItemProcessorTest {
     when(searchClient.getConsortiumItemCollection(any())).thenReturn(consortiumItemCollection);
     when(tenantResolver.getAffiliatedPermittedTenantIds(eq(EntityType.ITEM), any(), anyString(), anySet(), eq(itemIdentifier)))
       .thenReturn(Set.of("tenant1"));
-    when(itemStorageClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
+    when(itemClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
     when(holdingsReferenceService.getInstanceTitleByHoldingsRecordId(any(), anyString())).thenReturn("Instance Title");
     when(holdingsReferenceService.getHoldingsData(anyString(), anyString())).thenReturn(EMPTY);
 
@@ -158,7 +158,7 @@ class BulkEditItemProcessorTest {
 
     when(duplicationCheckerFactory.getIdentifiersToCheckDuplication(any())).thenReturn(new HashSet<>());
     when(permissionsValidator.isBulkEditReadPermissionExists(anyString(), any())).thenReturn(true);
-    when(itemStorageClient.getByQuery(anyString(), anyInt())).thenReturn(collection);
+    when(itemClient.getByQuery(anyString(), anyInt())).thenReturn(collection);
     when(holdingsReferenceService.getInstanceTitleByHoldingsRecordId(any(), anyString())).thenReturn("Instance Title");
     when(holdingsReferenceService.getHoldingsData(anyString(), anyString())).thenReturn(EMPTY);
 
@@ -195,7 +195,7 @@ class BulkEditItemProcessorTest {
     when(searchClient.getConsortiumItemCollection(any())).thenReturn(consortiumItemCollection);
     when(tenantResolver.getAffiliatedPermittedTenantIds(eq(EntityType.ITEM), any(), anyString(), anySet(), eq(itemIdentifier)))
       .thenReturn(Set.of("tenant1"));
-    when(itemStorageClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
+    when(itemClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
     when(holdingsReferenceService.getInstanceTitleByHoldingsRecordId(any(), anyString())).thenReturn("Instance Title");
     when(holdingsReferenceService.getHoldingsData(anyString(), anyString())).thenReturn(EMPTY);
 
@@ -233,7 +233,7 @@ class BulkEditItemProcessorTest {
     when(searchClient.getConsortiumItemCollection(any())).thenReturn(consortiumItemCollection);
     when(tenantResolver.getAffiliatedPermittedTenantIds(eq(EntityType.ITEM), any(), anyString(), anySet(), eq(itemIdentifier)))
             .thenReturn(Set.of(tenantId));
-    when(itemStorageClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
+    when(itemClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
     when(holdingsReferenceService.getInstanceTitleByHoldingsRecordId(any(), anyString())).thenReturn("Instance Title");
     when(holdingsReferenceService.getHoldingsData(anyString(), anyString())).thenReturn(EMPTY);
     doCallRealMethod().when(localReferenceDataService).enrichWithTenant(any(Item.class), anyString());
@@ -269,7 +269,7 @@ class BulkEditItemProcessorTest {
     when(searchClient.getConsortiumItemCollection(any())).thenReturn(consortiumItemCollection);
     when(tenantResolver.getAffiliatedPermittedTenantIds(eq(EntityType.ITEM), any(), anyString(), anySet(), eq(itemIdentifier)))
             .thenReturn(Set.of(tenantId));
-    when(itemStorageClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
+    when(itemClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
     when(holdingsReferenceService.getInstanceTitleByHoldingsRecordId(any(), anyString())).thenReturn("Instance Title");
     when(holdingsReferenceService.getHoldingsData(anyString(), anyString())).thenReturn(EMPTY);
     doCallRealMethod().when(localReferenceDataService).enrichWithTenant(any(Item.class), anyString());
@@ -305,7 +305,7 @@ class BulkEditItemProcessorTest {
     when(searchClient.getConsortiumItemCollection(any())).thenReturn(consortiumItemCollection);
     when(tenantResolver.getAffiliatedPermittedTenantIds(eq(EntityType.ITEM), any(), anyString(), anySet(), eq(itemIdentifier)))
             .thenReturn(Set.of(tenantId));
-    when(itemStorageClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
+    when(itemClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
     when(holdingsReferenceService.getInstanceTitleByHoldingsRecordId(any(), anyString())).thenReturn("Instance Title");
     when(holdingsReferenceService.getHoldingsData(anyString(), anyString())).thenReturn(EMPTY);
     doCallRealMethod().when(localReferenceDataService).enrichWithTenant(any(Item.class), anyString());
@@ -340,7 +340,7 @@ class BulkEditItemProcessorTest {
     when(searchClient.getConsortiumItemCollection(any())).thenReturn(consortiumItemCollection);
     when(tenantResolver.getAffiliatedPermittedTenantIds(eq(EntityType.ITEM), any(), anyString(), anySet(), eq(itemIdentifier)))
             .thenReturn(Set.of(tenantId));
-    when(itemStorageClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
+    when(itemClient.getByQuery(anyString(), anyInt())).thenReturn(itemCollection);
     when(holdingsReferenceService.getInstanceTitleByHoldingsRecordId(any(), anyString())).thenReturn("Instance Title");
     when(holdingsReferenceService.getHoldingsData(anyString(), anyString())).thenReturn(EMPTY);
 


### PR DESCRIPTION
Follow-up to [PR#448](https://github.com/folio-org/mod-bulk-operations/pull/448) with items client rollback (items storage -> items).