### PR TITLE
MODBULKOPS-533 - ECS - Filter out local instances when querying in Central tenant

### DIFF
--- a/src/main/java/org/folio/bulkops/util/FqmContentFetcher.java
+++ b/src/main/java/org/folio/bulkops/util/FqmContentFetcher.java
@@ -60,7 +60,6 @@ import org.folio.bulkops.domain.dto.ErrorType;
 import org.folio.bulkops.domain.entity.BulkOperationExecutionContent;
 import org.folio.bulkops.exception.FqmFetcherException;
 import org.folio.bulkops.service.ConsortiaService;
-import org.folio.bulkops.service.ErrorService;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -82,7 +81,6 @@ public class FqmContentFetcher {
   private final ObjectMapper objectMapper;
   private final FolioExecutionContext folioExecutionContext;
   private final ConsortiaService consortiaService;
-  private final ErrorService errorService;
 
   @PostConstruct
   private void logStartup() {
@@ -138,7 +136,13 @@ public class FqmContentFetcher {
             if (isInstance(entityType) && isCentralTenant &&
               !SHARED.equalsIgnoreCase(ofNullable(json.get(FQM_INSTANCE_SHARED_KEY)).map(Object::toString).orElse(EMPTY))) {
               var instanceId = ofNullable(json.get(FQM_INSTANCE_ID_KEY)).map(Object::toString).orElse(EMPTY);
-              errorService.saveError(operationId, instanceId, NO_MATCH_FOUND_MESSAGE, ErrorType.ERROR);
+              bulkOperationExecutionContents.add(BulkOperationExecutionContent.builder()
+                .identifier(instanceId)
+                .bulkOperationId(operationId)
+                .state(StateType.FAILED)
+                .errorType(ErrorType.ERROR)
+                .errorMessage(NO_MATCH_FOUND_MESSAGE)
+                .build());
               return EMPTY;
             }
 

--- a/src/main/java/org/folio/bulkops/util/FqmContentFetcher.java
+++ b/src/main/java/org/folio/bulkops/util/FqmContentFetcher.java
@@ -13,6 +13,7 @@ import static org.folio.bulkops.util.Constants.HOLDINGS_LOCATION_CALL_NUMBER_DEL
 import static org.folio.bulkops.util.Constants.ID;
 import static org.folio.bulkops.util.Constants.INSTANCE_TITLE;
 import static org.folio.bulkops.util.Constants.LINE_BREAK;
+import static org.folio.bulkops.util.Constants.NO_MATCH_FOUND_MESSAGE;
 import static org.folio.bulkops.util.Constants.PARENT_INSTANCES;
 import static org.folio.bulkops.util.Constants.PRECEDING_TITLES;
 import static org.folio.bulkops.util.Constants.SUCCEEDING_TITLES;
@@ -20,10 +21,12 @@ import static org.folio.bulkops.util.Constants.TENANT_ID;
 import static org.folio.bulkops.util.Constants.TITLE;
 import static org.folio.bulkops.util.FqmKeys.FQM_DATE_OF_PUBLICATION_KEY;
 import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCE_CHILD_INSTANCES_KEY;
+import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCE_ID_KEY;
 import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCE_PARENT_INSTANCES_KEY;
 import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCE_PRECEDING_TITLES_KEY;
 import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCE_PUBLICATION_KEY;
 import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCES_TITLE_KEY;
+import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCE_SHARED_KEY;
 import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCE_SUCCEEDING_TITLES_KEY;
 import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCE_TITLE_KEY;
 import static org.folio.bulkops.util.FqmKeys.FQM_INSTANCES_PUBLICATION_KEY;
@@ -57,6 +60,7 @@ import org.folio.bulkops.domain.dto.ErrorType;
 import org.folio.bulkops.domain.entity.BulkOperationExecutionContent;
 import org.folio.bulkops.exception.FqmFetcherException;
 import org.folio.bulkops.service.ConsortiaService;
+import org.folio.bulkops.service.ErrorService;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -67,6 +71,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class FqmContentFetcher {
 
+  public static final String SHARED = "Shared";
   public static final String TITLE_PATTERN = "%s. %s, %s";
   @Value("${application.fqm-fetcher.max_parallel_chunks}")
   private int maxParallelChunks;
@@ -77,6 +82,7 @@ public class FqmContentFetcher {
   private final ObjectMapper objectMapper;
   private final FolioExecutionContext folioExecutionContext;
   private final ConsortiaService consortiaService;
+  private final ErrorService errorService;
 
   @PostConstruct
   private void logStartup() {
@@ -96,9 +102,11 @@ public class FqmContentFetcher {
     try (var executor = Executors.newFixedThreadPool(maxParallelChunks)) {
       int chunks = (total + chunkSize - 1) / chunkSize;
 
+      boolean isCentralTenant = consortiaService.isTenantCentral(folioExecutionContext.getTenantId());
+
       List<CompletableFuture<InputStream>> tasks = IntStream.range(0, chunks)
           .mapToObj(chunk ->
-              CompletableFuture.supplyAsync(() -> task(queryId, entityType, chunk, total, bulkOperationExecutionContents, operationId), executor)
+              CompletableFuture.supplyAsync(() -> task(queryId, entityType, chunk, total, bulkOperationExecutionContents, operationId, isCentralTenant), executor)
           )
           .toList();
 
@@ -120,13 +128,20 @@ public class FqmContentFetcher {
   }
 
   private InputStream task(UUID queryId, EntityType entityType, int chunk, int total, List<BulkOperationExecutionContent> bulkOperationExecutionContents,
-                           UUID operationId) {
+                           UUID operationId, boolean isCentralTenant) {
     int offset = chunk * chunkSize;
     int limit = Math.min(chunkSize, total - offset);
     var response = queryClient.getQuery(queryId, offset, limit).getContent();
     return new ByteArrayInputStream(response.stream()
         .map(json -> {
           try {
+            if (isInstance(entityType) && isCentralTenant &&
+              !SHARED.equalsIgnoreCase(ofNullable(json.get(FQM_INSTANCE_SHARED_KEY)).map(Object::toString).orElse(EMPTY))) {
+              var instanceId = ofNullable(json.get(FQM_INSTANCE_ID_KEY)).map(Object::toString).orElse(EMPTY);
+              errorService.saveError(operationId, instanceId, NO_MATCH_FOUND_MESSAGE, ErrorType.ERROR);
+              return EMPTY;
+            }
+
             var jsonb = json.get(getEntityJsonKey(entityType));
             if (entityType == EntityType.USER) {
               return jsonb.toString();
@@ -187,7 +202,7 @@ public class FqmContentFetcher {
               jsonNode.put(INSTANCE_TITLE, title);
             }
 
-            if (entityType == EntityType.INSTANCE) {
+            if (isInstance(entityType)) {
               var value = json.get(FQM_INSTANCE_CHILD_INSTANCES_KEY);
               var childInstances = nonNull(value) ? objectMapper.readTree(value.toString()) : objectMapper.createArrayNode();
               jsonNode.putIfAbsent(CHILD_INSTANCES, childInstances);
@@ -258,5 +273,9 @@ public class FqmContentFetcher {
       return String.format(". %s, %s", isNull(publisher) || publisher.isNull() ? EMPTY : publisher.asText(), date.asText());
     }
     return EMPTY;
+  }
+
+  private boolean isInstance(EntityType entityType) {
+    return entityType == EntityType.INSTANCE || entityType == EntityType.INSTANCE_MARC;
   }
 }

--- a/src/main/java/org/folio/bulkops/util/FqmKeys.java
+++ b/src/main/java/org/folio/bulkops/util/FqmKeys.java
@@ -16,9 +16,11 @@ public class FqmKeys {
   public static final String FQM_HOLDINGS_CALL_NUMBER_SUFFIX_KEY = "holdings.call_number_suffix";
 
   public static final String FQM_INSTANCE_CHILD_INSTANCES_KEY = "instance.childInstances";
+  public static final String FQM_INSTANCE_ID_KEY = "instance.id";
   public static final String FQM_INSTANCE_PARENT_INSTANCES_KEY = "instance.parentInstances";
   public static final String FQM_INSTANCE_PRECEDING_TITLES_KEY = "instance.precedingTitles";
   public static final String FQM_INSTANCE_PUBLICATION_KEY = "instance.publication";
+  public static final String FQM_INSTANCE_SHARED_KEY = "instance.shared";
   public static final String FQM_INSTANCE_SUCCEEDING_TITLES_KEY = "instance.succeedingTitles";
   public static final String FQM_INSTANCE_TITLE_KEY = "instance.title";
   public static final String FQM_INSTANCES_PUBLICATION_KEY = "instances.publication";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,4 +104,4 @@ application:
   fqm-fetcher:
     max_chunk_size: ${FQM_MAX_CHUNK_SIZE:10000}
     max_parallel_chunks: ${FQM_MAX_PARALLEL_CHUNKS:10}
-  fqm-query-approach: ${FQM_QUERY_APPROACH:false}
+  fqm-query-approach: ${FQM_QUERY_APPROACH:true}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,4 +104,4 @@ application:
   fqm-fetcher:
     max_chunk_size: ${FQM_MAX_CHUNK_SIZE:10000}
     max_parallel_chunks: ${FQM_MAX_PARALLEL_CHUNKS:10}
-  fqm-query-approach: ${FQM_QUERY_APPROACH:true}
+  fqm-query-approach: ${FQM_QUERY_APPROACH:false}


### PR DESCRIPTION
[MODBULKOPS-533](https://folio-org.atlassian.net/browse/MODBULKOPS-533) - ECS - Filter out local instances when querying in Central tenant

## Purpose
Bulk edit does not support editing local instances from the central tenant so such instance will need to be filtered out when the user queries for instances in the central tenant.

## Approach
* Updated FqmContentFetcher logic
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
