### PR TITLE
MODBULKOPS-540 - ECS - Filter out shadow users when querying in Central tenant

### DIFF
--- a/src/main/java/org/folio/bulkops/util/Constants.java
+++ b/src/main/java/org/folio/bulkops/util/Constants.java
@@ -89,6 +89,7 @@ public class Constants {
   public static final String NO_INSTANCE_VIEW_PERMISSIONS = "User %s does not have required permission to view the instance record - %s=%s on the tenant %s";
   public static final String ERROR_STARTING_BULK_OPERATION = "Error starting Bulk Operation: ";
   public static final String CANNOT_GET_RECORD = "Cannot get data from %s due to %s";
+  public static final String MSG_SHADOW_RECORDS_CANNOT_BE_EDITED = "Shadow records cannot be bulk edited.";
 
   public static final String CSV_MSG_ERROR_TEMPLATE_OPTIMISTIC_LOCKING = "The record cannot be saved because it is not the most recent version. Stored version is %s, bulk edit version is %s.";
   public static final String RECORD_CANNOT_BE_UPDATED_ERROR_TEMPLATE = "%s cannot be updated because the record is associated with %s and %s is not associated with this tenant.";

--- a/src/main/java/org/folio/bulkops/util/FqmKeys.java
+++ b/src/main/java/org/folio/bulkops/util/FqmKeys.java
@@ -29,4 +29,6 @@ public class FqmKeys {
   public static final String FQM_ITEMS_JSONB_KEY = "items.jsonb";
 
   public static final String FQM_USERS_JSONB_KEY = "users.jsonb";
+  public static final String FQM_USERS_ID_KEY = "users.id";
+  public static final String FQM_USERS_TYPE_KEY = "users.type";
 }


### PR DESCRIPTION
[MODBULKOPS-540](https://folio-org.atlassian.net/browse/MODBULKOPS-540) - ECS - Filter out shadow users when querying in Central tenant

## Purpose
Bulk edit should not edit the shadow users when editing user records in the central tenant and those records should be filtered out when the user queries for users in the central tenant. 

## Approach
* Updated FQM content fetcher logic
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
