### PR TITLE
MODBULKOPS-560 - Notes, Subject columns are populated with not removed values on .csv files when it is expected to be empty

### DIFF
--- a/src/main/java/org/folio/bulkops/util/MarcCsvHelper.java
+++ b/src/main/java/org/folio/bulkops/util/MarcCsvHelper.java
@@ -116,7 +116,7 @@ public class MarcCsvHelper {
             Map<String, String> changedValues = new HashMap<>();
             for (var option : changedOptionsSet) {
               var index = instanceHeaderNames.indexOf(option);
-              if (index != -1 && StringUtils.isNotBlank(line[index])) {
+              if (index != -1 && nonNull(line[index])) {
                 changedValues.put(option, line[index]);
               }
             }

--- a/src/test/java/org/folio/bulkops/util/MarcCsvHelperOptionNotFoundTest.java
+++ b/src/test/java/org/folio/bulkops/util/MarcCsvHelperOptionNotFoundTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-public class MarcCsvHelperOptionNotFoundTest extends BaseTest {
+class MarcCsvHelperOptionNotFoundTest extends BaseTest {
 
     @Autowired
     private MarcCsvHelper marcCsvHelper;

--- a/src/test/java/org/folio/bulkops/util/MarcCsvHelperOptionNotFoundTest.java
+++ b/src/test/java/org/folio/bulkops/util/MarcCsvHelperOptionNotFoundTest.java
@@ -1,0 +1,69 @@
+package org.folio.bulkops.util;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.UUID;
+
+import lombok.SneakyThrows;
+import org.folio.bulkops.BaseTest;
+import org.folio.bulkops.client.MappingRulesClient;
+import org.folio.bulkops.client.RemoteFileSystemClient;
+import org.folio.bulkops.domain.entity.BulkOperation;
+import org.folio.bulkops.service.Marc21ReferenceProvider;
+import org.folio.bulkops.service.RuleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public class MarcCsvHelperOptionNotFoundTest extends BaseTest {
+
+    @Autowired
+    private MarcCsvHelper marcCsvHelper;
+
+    @MockitoBean
+    private Marc21ReferenceProvider marc21ReferenceProvider;
+    @MockitoBean
+    private MappingRulesClient mappingRulesClient;
+    @MockitoBean
+    private RemoteFileSystemClient remoteFileSystemClient;
+    @MockitoBean
+    private RuleService ruleService;
+
+    @Test
+    @SneakyThrows
+    void shouldEnrichCsvWithEmptyValueBecauseOfOptionNotFound() {
+        var fileName = "file.csv";
+        var operationId = UUID.randomUUID();
+        var operation = BulkOperation.builder()
+                .id(operationId)
+                .status(REVIEW_CHANGES)
+                .entityType(org.folio.bulkops.domain.dto.EntityType.INSTANCE_MARC)
+                .linkToModifiedRecordsMarcCsvFile(fileName)
+                .build();
+
+        var content = new FileInputStream("src/test/resources/files/instance.csv").readAllBytes();
+
+        when(mappingRulesClient.getMarcBibMappingRules())
+                .thenReturn(Files.readString(Path.of("src/test/resources/files/mappingRulesResponse.json")));
+        when(remoteFileSystemClient.get(fileName))
+                .thenReturn(new FileInputStream("src/test/resources/files/marc_csv_empty_notes.csv"));
+        when(ruleService.getMarcRules(operationId))
+                .thenReturn(new org.folio.bulkops.domain.dto.BulkOperationMarcRuleCollection()
+                        .bulkOperationMarcRules(singletonList(new org.folio.bulkops.domain.dto.BulkOperationMarcRule().tag("500"))));
+        when(marc21ReferenceProvider.getChangedOptionsSetForCsv(any(org.folio.bulkops.domain.dto.BulkOperationMarcRuleCollection.class)))
+                .thenReturn(Set.of("Not notes"));
+
+        var res = marcCsvHelper.enrichCsvWithMarcChanges(content, operation);
+
+        var expectedInstanceNotes = "";
+        assertThat(new String(res)).contains(expectedInstanceNotes);
+    }
+}

--- a/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
+++ b/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
@@ -2,21 +2,15 @@ package org.folio.bulkops.util;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.folio.bulkops.domain.bean.Instance.INSTANCE_HRID;
 import static org.folio.bulkops.domain.dto.OperationStatusType.APPLY_CHANGES;
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import lombok.SneakyThrows;
 import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.client.MappingRulesClient;
 import org.folio.bulkops.client.RemoteFileSystemClient;
-import org.folio.bulkops.domain.bean.Instance;
 import org.folio.bulkops.domain.dto.BulkOperationMarcRule;
 import org.folio.bulkops.domain.dto.BulkOperationMarcRuleCollection;
 import org.folio.bulkops.domain.dto.EntityType;
@@ -24,9 +18,6 @@ import org.folio.bulkops.domain.dto.InstanceNoteType;
 import org.folio.bulkops.domain.dto.OperationStatusType;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.InstanceReferenceService;
-import org.folio.bulkops.service.Marc21ReferenceProvider;
-import org.folio.bulkops.service.MarcToUnifiedTableRowMapper;
-import org.folio.bulkops.service.NoteTableUpdater;
 import org.folio.bulkops.service.RuleService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,12 +29,9 @@ import org.marc4j.marc.impl.SubfieldImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 class MarcCsvHelperTest extends BaseTest {
@@ -211,110 +199,30 @@ class MarcCsvHelperTest extends BaseTest {
   }
 
   @Test
-  void getChangedMarcData_shouldPutEmptyStringValue() throws Exception {
-    Marc21ReferenceProvider marc21ReferenceProvider = mock(Marc21ReferenceProvider.class);
-    var marcCsvHelper = new MarcCsvHelper(
-            mock(NoteTableUpdater.class),
-            mock(MarcToUnifiedTableRowMapper.class),
-            remoteFileSystemClient,
-            ruleService,
-            marc21ReferenceProvider,
-            objectMapper
-    );
-
-    var instanceHeaderNames = UnifiedTableHeaderBuilder.getEmptyTableWithHeaders(Instance.class)
-            .getHeader().stream().map(org.folio.bulkops.domain.dto.Cell::getValue).toList();
-    var hridIndex = instanceHeaderNames.indexOf(INSTANCE_HRID);
-    var option = instanceHeaderNames.get(hridIndex + 1); // pick a column after hrid
-
-    var fileName = "test.csv";
-    var bulkOperation = BulkOperation.builder()
-            .id(UUID.randomUUID())
-            .status(OperationStatusType.REVIEW_CHANGES)
+  @SneakyThrows
+  void shouldEnrichCsvWithEmptyValue() {
+    var fileName = "file.csv";
+    var operationId = UUID.randomUUID();
+    var operation = BulkOperation.builder()
+            .id(operationId)
+            .status(REVIEW_CHANGES)
             .entityType(EntityType.INSTANCE_MARC)
             .linkToModifiedRecordsMarcCsvFile(fileName)
             .build();
 
-    // Prepare CSV: hrid, option, ...; row: hridValue, "", ...
-    String[] header = instanceHeaderNames.toArray(new String[0]);
-    String[] row = new String[header.length];
-    row[hridIndex] = "hridValue";
-    row[instanceHeaderNames.indexOf(option)] = ""; // empty string
+    var content = new FileInputStream("src/test/resources/files/instance.csv").readAllBytes();
 
-    var csvContent = String.join(",", header) + "\n" + String.join(",", row) + "\n";
-
-    // Mock ObjectReader and all relevant ObjectMapper methods
-    ObjectReader objectReader = mock(ObjectReader.class);
-    when(objectReader.forType(any(Class.class))).thenReturn(objectReader);
-    when(remoteFileSystemClient.get(fileName)).thenReturn(new ByteArrayInputStream(csvContent.getBytes()));
-    when(ruleService.getMarcRules(bulkOperation.getId()))
+    when(mappingRulesClient.getMarcBibMappingRules())
+            .thenReturn(Files.readString(Path.of("src/test/resources/files/mappingRulesResponse.json")));
+    when(remoteFileSystemClient.get(fileName))
+            .thenReturn(new FileInputStream("src/test/resources/files/marc_csv_empty_notes.csv"));
+    when(ruleService.getMarcRules(operationId))
             .thenReturn(new BulkOperationMarcRuleCollection()
-                    .bulkOperationMarcRules(singletonList(new BulkOperationMarcRule().tag(option))));
-    when(marc21ReferenceProvider.getChangedOptionsSetForCsv(any())).thenReturn(Set.of(option));
-    doNothing().when(marc21ReferenceProvider).updateMappingRules();
+                    .bulkOperationMarcRules(singletonList(new BulkOperationMarcRule().tag("500"))));
 
-    // Use reflection to call private method
-    var method = MarcCsvHelper.class.getDeclaredMethod("getChangedMarcData", BulkOperation.class);
-    method.setAccessible(true);
-    var result = method.invoke(marcCsvHelper, bulkOperation);
+    var res = marcCsvHelper.enrichCsvWithMarcChanges(content, operation);
 
-    assertThat(result).isInstanceOf(Map.class);
-    var resultMap = (Map<String, Map<String, String>>) result;
-    assertThat(resultMap).containsKey("hridValue");
-    assertThat(resultMap.get("hridValue")).containsEntry(option, "");
-  }
-
-  @Test
-  void getChangedMarcData_shouldSkipWhenValueIsNull() throws Exception {
-    Marc21ReferenceProvider marc21ReferenceProvider = mock(Marc21ReferenceProvider.class);
-    var marcCsvHelper = new MarcCsvHelper(
-            mock(NoteTableUpdater.class),
-            mock(MarcToUnifiedTableRowMapper.class),
-            remoteFileSystemClient,
-            ruleService,
-            marc21ReferenceProvider,
-            objectMapper
-    );
-
-    var instanceHeaderNames = UnifiedTableHeaderBuilder.getEmptyTableWithHeaders(Instance.class)
-            .getHeader().stream().map(org.folio.bulkops.domain.dto.Cell::getValue).toList();
-    var hridIndex = instanceHeaderNames.indexOf(INSTANCE_HRID);
-    var option = instanceHeaderNames.get(hridIndex + 1); // pick a column after hrid
-
-    var fileName = "test_null_value.csv";
-    var bulkOperation = BulkOperation.builder()
-            .id(UUID.randomUUID())
-            .status(OperationStatusType.REVIEW_CHANGES)
-            .entityType(EntityType.INSTANCE_MARC)
-            .linkToModifiedRecordsMarcCsvFile(fileName)
-            .build();
-
-    // Prepare CSV: hrid, option, ...; row: hridValue, null, ...
-    String[] header = instanceHeaderNames.toArray(new String[0]);
-    String[] row = new String[header.length];
-    row[hridIndex] = "hridValue";
-    // Explicitly set the option column to null
-    row[instanceHeaderNames.indexOf(option)] = null;
-
-    var csvContent = String.join(",", header) + "\n" + String.join(",", row) + "\n";
-
-    ObjectReader objectReader = mock(ObjectReader.class);
-    when(objectReader.forType(any(Class.class))).thenReturn(objectReader);
-    when(remoteFileSystemClient.get(fileName)).thenReturn(new ByteArrayInputStream(csvContent.getBytes()));
-    when(ruleService.getMarcRules(bulkOperation.getId()))
-            .thenReturn(new BulkOperationMarcRuleCollection()
-                    .bulkOperationMarcRules(singletonList(new BulkOperationMarcRule().tag(option))));
-    when(marc21ReferenceProvider.getChangedOptionsSetForCsv(any())).thenReturn(Set.of(option));
-    doNothing().when(marc21ReferenceProvider).updateMappingRules();
-
-    var method = MarcCsvHelper.class.getDeclaredMethod("getChangedMarcData", BulkOperation.class);
-    method.setAccessible(true);
-    var result = method.invoke(marcCsvHelper, bulkOperation);
-
-    assertThat(result).isInstanceOf(Map.class);
-    var resultMap = (Map<String, Map<String, String>>) result;
-    assertThat(resultMap).containsKey("hridValue");
-    // Should not contain the option key since line[index] == null
-    assertThat(resultMap.get("hridValue").get("Source")).isEqualTo("null");
+    var expectedInstanceNotes = "";
+    assertThat(new String(res)).contains(expectedInstanceNotes);
   }
 }

--- a/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
+++ b/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
@@ -4,9 +4,9 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.bulkops.domain.dto.OperationStatusType.APPLY_CHANGES;
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.client.MappingRulesClient;
@@ -18,7 +18,9 @@ import org.folio.bulkops.domain.dto.InstanceNoteType;
 import org.folio.bulkops.domain.dto.OperationStatusType;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.InstanceReferenceService;
+import org.folio.bulkops.service.Marc21ReferenceProvider;
 import org.folio.bulkops.service.RuleService;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -27,18 +29,18 @@ import org.marc4j.marc.impl.LeaderImpl;
 import org.marc4j.marc.impl.RecordImpl;
 import org.marc4j.marc.impl.SubfieldImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.UUID;
 
 class MarcCsvHelperTest extends BaseTest {
   @Autowired
   private MarcCsvHelper marcCsvHelper;
-  @Autowired
-  private ObjectMapper objectMapper;
 
   @MockitoBean
   private InstanceReferenceService instanceReferenceService;
@@ -200,7 +202,7 @@ class MarcCsvHelperTest extends BaseTest {
 
   @Test
   @SneakyThrows
-  void shouldEnrichCsvWithEmptyValue() {
+  void shouldEnrichCsvWithEmptyValueForNotes() {
     var fileName = "file.csv";
     var operationId = UUID.randomUUID();
     var operation = BulkOperation.builder()
@@ -224,5 +226,43 @@ class MarcCsvHelperTest extends BaseTest {
 
     var expectedInstanceNotes = "";
     assertThat(new String(res)).contains(expectedInstanceNotes);
+  }
+
+  @Nested
+  @SpringBootTest
+  class MarcCsvHelperOptionNotFoundTest {
+
+    @MockitoBean
+    private Marc21ReferenceProvider marc21ReferenceProvider;
+
+    @Test
+    @SneakyThrows
+    void shouldEnrichCsvWithEmptyValueBecauseOfOptionNotFound() {
+      var fileName = "file.csv";
+      var operationId = UUID.randomUUID();
+      var operation = BulkOperation.builder()
+              .id(operationId)
+              .status(REVIEW_CHANGES)
+              .entityType(EntityType.INSTANCE_MARC)
+              .linkToModifiedRecordsMarcCsvFile(fileName)
+              .build();
+
+      var content = new FileInputStream("src/test/resources/files/instance.csv").readAllBytes();
+
+      when(mappingRulesClient.getMarcBibMappingRules())
+              .thenReturn(Files.readString(Path.of("src/test/resources/files/mappingRulesResponse.json")));
+      when(remoteFileSystemClient.get(fileName))
+              .thenReturn(new FileInputStream("src/test/resources/files/marc_csv_empty_notes.csv"));
+      when(ruleService.getMarcRules(operationId))
+              .thenReturn(new BulkOperationMarcRuleCollection()
+                      .bulkOperationMarcRules(singletonList(new BulkOperationMarcRule().tag("500"))));
+      when(marc21ReferenceProvider.getChangedOptionsSetForCsv(any()))
+              .thenReturn(Set.of("Not notes"));
+
+      var res = marcCsvHelper.enrichCsvWithMarcChanges(content, operation);
+
+      var expectedInstanceNotes = "";
+      assertThat(new String(res)).contains(expectedInstanceNotes);
+    }
   }
 }

--- a/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
+++ b/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
@@ -4,7 +4,6 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.bulkops.domain.dto.OperationStatusType.APPLY_CHANGES;
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import lombok.SneakyThrows;
@@ -18,9 +17,7 @@ import org.folio.bulkops.domain.dto.InstanceNoteType;
 import org.folio.bulkops.domain.dto.OperationStatusType;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.InstanceReferenceService;
-import org.folio.bulkops.service.Marc21ReferenceProvider;
 import org.folio.bulkops.service.RuleService;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -29,13 +26,11 @@ import org.marc4j.marc.impl.LeaderImpl;
 import org.marc4j.marc.impl.RecordImpl;
 import org.marc4j.marc.impl.SubfieldImpl;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Set;
 import java.util.UUID;
 
 class MarcCsvHelperTest extends BaseTest {
@@ -226,43 +221,5 @@ class MarcCsvHelperTest extends BaseTest {
 
     var expectedInstanceNotes = "";
     assertThat(new String(res)).contains(expectedInstanceNotes);
-  }
-
-  @Nested
-  @SpringBootTest
-  class MarcCsvHelperOptionNotFoundTest {
-
-    @MockitoBean
-    private Marc21ReferenceProvider marc21ReferenceProvider;
-
-    @Test
-    @SneakyThrows
-    void shouldEnrichCsvWithEmptyValueBecauseOfOptionNotFound() {
-      var fileName = "file.csv";
-      var operationId = UUID.randomUUID();
-      var operation = BulkOperation.builder()
-              .id(operationId)
-              .status(REVIEW_CHANGES)
-              .entityType(EntityType.INSTANCE_MARC)
-              .linkToModifiedRecordsMarcCsvFile(fileName)
-              .build();
-
-      var content = new FileInputStream("src/test/resources/files/instance.csv").readAllBytes();
-
-      when(mappingRulesClient.getMarcBibMappingRules())
-              .thenReturn(Files.readString(Path.of("src/test/resources/files/mappingRulesResponse.json")));
-      when(remoteFileSystemClient.get(fileName))
-              .thenReturn(new FileInputStream("src/test/resources/files/marc_csv_empty_notes.csv"));
-      when(ruleService.getMarcRules(operationId))
-              .thenReturn(new BulkOperationMarcRuleCollection()
-                      .bulkOperationMarcRules(singletonList(new BulkOperationMarcRule().tag("500"))));
-      when(marc21ReferenceProvider.getChangedOptionsSetForCsv(any()))
-              .thenReturn(Set.of("Not notes"));
-
-      var res = marcCsvHelper.enrichCsvWithMarcChanges(content, operation);
-
-      var expectedInstanceNotes = "";
-      assertThat(new String(res)).contains(expectedInstanceNotes);
-    }
   }
 }

--- a/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
+++ b/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
@@ -42,7 +42,6 @@ import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -61,12 +60,6 @@ class MarcCsvHelperTest extends BaseTest {
   private RemoteFileSystemClient remoteFileSystemClient;
   @MockitoBean
   private RuleService ruleService;
-  @MockitoBean
-  private NoteTableUpdater noteTableUpdater;
-  @MockitoBean
-  private MarcToUnifiedTableRowMapper marcToUnifiedTableRowMapper;
-  @MockitoBean
-  private Marc21ReferenceProvider marc21ReferenceProvider;
 
   @Test
   void shouldGetModifiedDataForCsv() {
@@ -219,9 +212,10 @@ class MarcCsvHelperTest extends BaseTest {
 
   @Test
   void getChangedMarcData_shouldPutEmptyStringValue() throws Exception {
+    Marc21ReferenceProvider marc21ReferenceProvider = mock(Marc21ReferenceProvider.class);
     var marcCsvHelper = new MarcCsvHelper(
-            noteTableUpdater,
-            marcToUnifiedTableRowMapper,
+            mock(NoteTableUpdater.class),
+            mock(MarcToUnifiedTableRowMapper.class),
             remoteFileSystemClient,
             ruleService,
             marc21ReferenceProvider,

--- a/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
+++ b/src/test/java/org/folio/bulkops/util/MarcCsvHelperTest.java
@@ -2,14 +2,21 @@ package org.folio.bulkops.util;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.bulkops.domain.bean.Instance.INSTANCE_HRID;
 import static org.folio.bulkops.domain.dto.OperationStatusType.APPLY_CHANGES;
 import static org.folio.bulkops.domain.dto.OperationStatusType.REVIEW_CHANGES;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import lombok.SneakyThrows;
 import org.folio.bulkops.BaseTest;
 import org.folio.bulkops.client.MappingRulesClient;
 import org.folio.bulkops.client.RemoteFileSystemClient;
+import org.folio.bulkops.domain.bean.Instance;
 import org.folio.bulkops.domain.dto.BulkOperationMarcRule;
 import org.folio.bulkops.domain.dto.BulkOperationMarcRuleCollection;
 import org.folio.bulkops.domain.dto.EntityType;
@@ -17,6 +24,9 @@ import org.folio.bulkops.domain.dto.InstanceNoteType;
 import org.folio.bulkops.domain.dto.OperationStatusType;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.service.InstanceReferenceService;
+import org.folio.bulkops.service.Marc21ReferenceProvider;
+import org.folio.bulkops.service.MarcToUnifiedTableRowMapper;
+import org.folio.bulkops.service.NoteTableUpdater;
 import org.folio.bulkops.service.RuleService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,23 +38,35 @@ import org.marc4j.marc.impl.SubfieldImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 class MarcCsvHelperTest extends BaseTest {
   @Autowired
   private MarcCsvHelper marcCsvHelper;
+  @Autowired
+  private ObjectMapper objectMapper;
 
-   @MockitoBean
+  @MockitoBean
   private InstanceReferenceService instanceReferenceService;
-   @MockitoBean
+  @MockitoBean
   private MappingRulesClient mappingRulesClient;
-   @MockitoBean
+  @MockitoBean
   private RemoteFileSystemClient remoteFileSystemClient;
-   @MockitoBean
+  @MockitoBean
   private RuleService ruleService;
+  @MockitoBean
+  private NoteTableUpdater noteTableUpdater;
+  @MockitoBean
+  private MarcToUnifiedTableRowMapper marcToUnifiedTableRowMapper;
+  @MockitoBean
+  private Marc21ReferenceProvider marc21ReferenceProvider;
 
   @Test
   void shouldGetModifiedDataForCsv() {
@@ -193,5 +215,58 @@ class MarcCsvHelperTest extends BaseTest {
 
     var expectedInstanceNotes = "General note;General note text;false";
     assertThat(new String(res)).contains(expectedInstanceNotes);
+  }
+
+  @Test
+  void getChangedMarcData_shouldPutEmptyStringValue() throws Exception {
+    var marcCsvHelper = new MarcCsvHelper(
+            noteTableUpdater,
+            marcToUnifiedTableRowMapper,
+            remoteFileSystemClient,
+            ruleService,
+            marc21ReferenceProvider,
+            objectMapper
+    );
+
+    var instanceHeaderNames = UnifiedTableHeaderBuilder.getEmptyTableWithHeaders(Instance.class)
+            .getHeader().stream().map(org.folio.bulkops.domain.dto.Cell::getValue).toList();
+    var hridIndex = instanceHeaderNames.indexOf(INSTANCE_HRID);
+    var option = instanceHeaderNames.get(hridIndex + 1); // pick a column after hrid
+
+    var fileName = "test.csv";
+    var bulkOperation = BulkOperation.builder()
+            .id(UUID.randomUUID())
+            .status(OperationStatusType.REVIEW_CHANGES)
+            .entityType(EntityType.INSTANCE_MARC)
+            .linkToModifiedRecordsMarcCsvFile(fileName)
+            .build();
+
+    // Prepare CSV: hrid, option, ...; row: hridValue, "", ...
+    String[] header = instanceHeaderNames.toArray(new String[0]);
+    String[] row = new String[header.length];
+    row[hridIndex] = "hridValue";
+    row[instanceHeaderNames.indexOf(option)] = ""; // empty string
+
+    var csvContent = String.join(",", header) + "\n" + String.join(",", row) + "\n";
+
+    // Mock ObjectReader and all relevant ObjectMapper methods
+    ObjectReader objectReader = mock(ObjectReader.class);
+    when(objectReader.forType(any(Class.class))).thenReturn(objectReader);
+    when(remoteFileSystemClient.get(fileName)).thenReturn(new ByteArrayInputStream(csvContent.getBytes()));
+    when(ruleService.getMarcRules(bulkOperation.getId()))
+            .thenReturn(new BulkOperationMarcRuleCollection()
+                    .bulkOperationMarcRules(singletonList(new BulkOperationMarcRule().tag(option))));
+    when(marc21ReferenceProvider.getChangedOptionsSetForCsv(any())).thenReturn(Set.of(option));
+    doNothing().when(marc21ReferenceProvider).updateMappingRules();
+
+    // Use reflection to call private method
+    var method = MarcCsvHelper.class.getDeclaredMethod("getChangedMarcData", BulkOperation.class);
+    method.setAccessible(true);
+    var result = method.invoke(marcCsvHelper, bulkOperation);
+
+    assertThat(result).isInstanceOf(Map.class);
+    var resultMap = (Map<String, Map<String, String>>) result;
+    assertThat(resultMap).containsKey("hridValue");
+    assertThat(resultMap.get("hridValue")).containsEntry(option, "");
   }
 }

--- a/src/test/resources/files/marc_csv_empty_notes.csv
+++ b/src/test/resources/files/marc_csv_empty_notes.csv
@@ -1,0 +1,1 @@
+69640328-788e-43fc-9c3c-af39e243f3b7,false,,false,false,inst000000000001,FOLIO,2023-12-27,Other,serial,some type: some code - some name,Sample note,ABA Journal,Index title,series,Sample contributor,,2021 | 2022,Physical description1 | Physical description2,text,textbook,computer -- other,eng | fre,freq1 | freq2,range1 | range2,"",,,


### PR DESCRIPTION
[MODBULKOPS-560](https://folio-org.atlassian.net/browse/MODBULKOPS-560) - Notes, Subject columns are populated with not removed values on .csv files when it is expected to be empty

## Purpose
Autotests found that when do bulk edit Instances with source MARC “Notes“ column in .csv file downloaded from “Are you sure“ form, Confirmation screen displays values that should not be displayed (going to be removed), find examples of actions below:
1.  find & remove subfield
2.  find & remove field
3.  remove all
The issue is reproduced only in case “Notes“ column is going to be empty for the record. Works as expected in case “Notes“ column is not going to be empty.
The same issue is reproduced for “Subject“ column.

## Approach
Remove filter for empty string.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
