### PR TITLE
MODBULKOPS-603 - Occasionally Matching preview displays not all uploaded records when upload .csv file with large number of identifiers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-cql</artifactId>
       <version>${folio-spring-cql.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.z3950.zing</groupId>
+                <artifactId>cql-java</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,6 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-cql</artifactId>
       <version>${folio-spring-cql.version}</version>
-        <exclusions>
-            <exclusion>
-                <groupId>org.z3950.zing</groupId>
-                <artifactId>cql-java</artifactId>
-            </exclusion>
-        </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/bulkops/batch/jobs/processidentifiers/IdentifiersWriteListener.java
+++ b/src/main/java/org/folio/bulkops/batch/jobs/processidentifiers/IdentifiersWriteListener.java
@@ -39,10 +39,10 @@ public class IdentifiersWriteListener<T> implements ItemWriteListener<T> {
     int processed;
     int matched;
     synchronized (this) {
-      var totalCsvLines = jobExecution.getJobParameters().getLong(TOTAL_CSV_LINES);
       var context = jobExecution.getExecutionContext();
       processed = list.size();
       matched = list.size();
+      var totalCsvLines = jobExecution.getJobParameters().getLong(TOTAL_CSV_LINES);
       if (context.containsKey(NUMBER_OF_PROCESSED_IDENTIFIERS)) {
         processed += context.getInt(NUMBER_OF_PROCESSED_IDENTIFIERS);
       }

--- a/src/main/java/org/folio/bulkops/batch/jobs/processidentifiers/IdentifiersWriteListener.java
+++ b/src/main/java/org/folio/bulkops/batch/jobs/processidentifiers/IdentifiersWriteListener.java
@@ -36,21 +36,25 @@ public class IdentifiersWriteListener<T> implements ItemWriteListener<T> {
 
   @Override
   public void afterWrite(Chunk<? extends T> list) {
-    var totalCsvLines = jobExecution.getJobParameters().getLong(TOTAL_CSV_LINES);
-    int processed = list.size();
-    int matched = list.size();
-    var context = jobExecution.getExecutionContext();
-    if (context.containsKey(NUMBER_OF_PROCESSED_IDENTIFIERS)) {
-      processed += context.getInt(NUMBER_OF_PROCESSED_IDENTIFIERS);
+    int processed;
+    int matched;
+    synchronized (this) {
+      var totalCsvLines = jobExecution.getJobParameters().getLong(TOTAL_CSV_LINES);
+      var context = jobExecution.getExecutionContext();
+      processed = list.size();
+      matched = list.size();
+      if (context.containsKey(NUMBER_OF_PROCESSED_IDENTIFIERS)) {
+        processed += context.getInt(NUMBER_OF_PROCESSED_IDENTIFIERS);
+      }
+      if (context.containsKey(NUMBER_OF_MATCHED_RECORDS)) {
+        matched += context.getInt(NUMBER_OF_MATCHED_RECORDS);
+      }
+      if (nonNull(totalCsvLines) && processed > totalCsvLines) {
+        processed = totalCsvLines.intValue();
+      }
+      context.putInt(NUMBER_OF_PROCESSED_IDENTIFIERS, processed);
+      context.putInt(NUMBER_OF_MATCHED_RECORDS, matched);
     }
-    if (context.containsKey(NUMBER_OF_MATCHED_RECORDS)) {
-      matched += context.getInt(NUMBER_OF_MATCHED_RECORDS);
-    }
-    if (nonNull(totalCsvLines) && processed > totalCsvLines) {
-      processed = totalCsvLines.intValue();
-    }
-    context.putInt(NUMBER_OF_PROCESSED_IDENTIFIERS, processed);
-    context.putInt(NUMBER_OF_MATCHED_RECORDS, matched);
 
     var bulkOperation =
         ofNullable(jobExecution.getJobParameters().getString(BULK_OPERATION_ID))
@@ -63,6 +67,7 @@ public class IdentifiersWriteListener<T> implements ItemWriteListener<T> {
                         "Bulk operation was not found, aborting batch execution."));
 
     bulkOperation.setProcessedNumOfRecords(processed);
+    bulkOperation.setMatchedNumOfRecords(matched);
     bulkOperationRepository.save(bulkOperation);
   }
 }

--- a/src/main/java/org/folio/bulkops/repository/BulkOperationRepository.java
+++ b/src/main/java/org/folio/bulkops/repository/BulkOperationRepository.java
@@ -4,9 +4,20 @@ import java.util.Optional;
 import java.util.UUID;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface BulkOperationRepository extends JpaRepository<BulkOperation, UUID> {
   Optional<BulkOperation> findByDataImportJobProfileId(UUID profileId);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE bulk_operation b SET b.processedNumOfRecords = :processed, b.matchedNumOfRecords = :matched WHERE b.id = :id")
+  void updateExecutionCounters(@Param("id") UUID id,
+                               @Param("processed") int processed,
+                               @Param("matched") int matched);
 }

--- a/src/main/java/org/folio/bulkops/repository/BulkOperationRepository.java
+++ b/src/main/java/org/folio/bulkops/repository/BulkOperationRepository.java
@@ -16,8 +16,9 @@ public interface BulkOperationRepository extends JpaRepository<BulkOperation, UU
 
   @Modifying
   @Transactional
-  @Query("UPDATE bulk_operation b SET b.processedNumOfRecords = :processed, b.matchedNumOfRecords = :matched WHERE b.id = :id")
-  void updateExecutionCounters(@Param("id") UUID id,
-                               @Param("processed") int processed,
-                               @Param("matched") int matched);
+  @Query(
+      "UPDATE bulk_operation b SET b.processedNumOfRecords = :processed, "
+          + "b.matchedNumOfRecords = :matched WHERE b.id = :id")
+  void updateExecutionCounters(
+      @Param("id") UUID id, @Param("processed") int processed, @Param("matched") int matched);
 }

--- a/src/main/java/org/folio/bulkops/repository/BulkOperationRepository.java
+++ b/src/main/java/org/folio/bulkops/repository/BulkOperationRepository.java
@@ -17,7 +17,7 @@ public interface BulkOperationRepository extends JpaRepository<BulkOperation, UU
   @Modifying
   @Transactional
   @Query(
-      "UPDATE bulk_operation b SET b.processedNumOfRecords = :processed, "
+      "UPDATE BulkOperation b SET b.processedNumOfRecords = :processed, "
           + "b.matchedNumOfRecords = :matched WHERE b.id = :id")
   void updateExecutionCounters(
       @Param("id") UUID id, @Param("processed") int processed, @Param("matched") int matched);

--- a/src/main/java/org/folio/bulkops/service/QueryService.java
+++ b/src/main/java/org/folio/bulkops/service/QueryService.java
@@ -321,9 +321,7 @@ public class QueryService {
         }
 
         operation.setUsedTenants(new ArrayList<>(usedTenants));
-        if (numProcessed % STATISTICS_UPDATING_STEP != 0) {
-          updateOperationExecutionStatus(operation, numProcessed, numMatched);
-        }
+        updateOperationExecutionStatus(operation, numProcessed, numMatched);
         errorService.saveErrorsAfterQuery(bulkOperationExecutionContents, operation);
       }
     } finally {

--- a/src/main/java/org/folio/bulkops/service/QueryService.java
+++ b/src/main/java/org/folio/bulkops/service/QueryService.java
@@ -245,6 +245,8 @@ public class QueryService {
       List<BulkOperationExecutionContent> bulkOperationExecutionContents)
       throws IOException, CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
     Writer writerForTriggeringCsvFile = null;
+    int numMatched = 0;
+    int numProcessed = 0;
     try {
       if (ApproachType.QUERY == operation.getApproach()) {
         writerForTriggeringCsvFile = remoteFileSystemClient.writer(triggeringCsvFileName);
@@ -255,9 +257,6 @@ public class QueryService {
         var entityClass = resolveEntityClass(operation.getEntityType());
         var extendedEntityClass = resolveExtendedEntityClass(operation.getEntityType());
         var csvWriter = new BulkOperationsEntityCsvWriter(writerForResultCsvFile, entityClass);
-
-        int numMatched = 0;
-        int numProcessed = 0;
         var iterator =
             isNull(is)
                 ? MappingIterator.emptyIterator()
@@ -321,10 +320,13 @@ public class QueryService {
         }
 
         operation.setUsedTenants(new ArrayList<>(usedTenants));
-        updateOperationExecutionStatus(operation, numProcessed, numMatched);
+        if (numProcessed % STATISTICS_UPDATING_STEP != 0) {
+          updateOperationExecutionStatus(operation, numProcessed, numMatched);
+        }
         errorService.saveErrorsAfterQuery(bulkOperationExecutionContents, operation);
       }
     } finally {
+      updateOperationExecutionStatus(operation, numProcessed, numMatched);
       if (writerForTriggeringCsvFile != null) {
         writerForTriggeringCsvFile.close();
       }

--- a/src/main/java/org/folio/bulkops/service/QueryService.java
+++ b/src/main/java/org/folio/bulkops/service/QueryService.java
@@ -245,8 +245,6 @@ public class QueryService {
       List<BulkOperationExecutionContent> bulkOperationExecutionContents)
       throws IOException, CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
     Writer writerForTriggeringCsvFile = null;
-    int numMatched = 0;
-    int numProcessed = 0;
     try {
       if (ApproachType.QUERY == operation.getApproach()) {
         writerForTriggeringCsvFile = remoteFileSystemClient.writer(triggeringCsvFileName);
@@ -257,6 +255,8 @@ public class QueryService {
         var entityClass = resolveEntityClass(operation.getEntityType());
         var extendedEntityClass = resolveExtendedEntityClass(operation.getEntityType());
         var csvWriter = new BulkOperationsEntityCsvWriter(writerForResultCsvFile, entityClass);
+        int numMatched = 0;
+        int numProcessed = 0;
         var iterator =
             isNull(is)
                 ? MappingIterator.emptyIterator()
@@ -326,7 +326,6 @@ public class QueryService {
         errorService.saveErrorsAfterQuery(bulkOperationExecutionContents, operation);
       }
     } finally {
-      updateOperationExecutionStatus(operation, numProcessed, numMatched);
       if (writerForTriggeringCsvFile != null) {
         writerForTriggeringCsvFile.close();
       }

--- a/src/main/java/org/folio/bulkops/service/QueryService.java
+++ b/src/main/java/org/folio/bulkops/service/QueryService.java
@@ -255,6 +255,7 @@ public class QueryService {
         var entityClass = resolveEntityClass(operation.getEntityType());
         var extendedEntityClass = resolveExtendedEntityClass(operation.getEntityType());
         var csvWriter = new BulkOperationsEntityCsvWriter(writerForResultCsvFile, entityClass);
+
         int numMatched = 0;
         int numProcessed = 0;
         var iterator =
@@ -336,7 +337,7 @@ public class QueryService {
       BulkOperation operation, int numProcessed, int numMatched) {
     operation.setProcessedNumOfRecords(numProcessed);
     operation.setMatchedNumOfRecords(numMatched);
-    bulkOperationRepository.save(operation);
+    bulkOperationRepository.updateExecutionCounters(operation.getId(), numProcessed, numMatched);
   }
 
   private void failAndSaveBulkOperation(BulkOperation bulkOperation, String errorMessage) {


### PR DESCRIPTION
[MODBULKOPS-603](https://folio-org.atlassian.net/browse/MODBULKOPS-603) - Occasionally Matching preview displays not all uploaded records when upload .csv file with large number of identifiers

## Purpose
From time to time in result of upload file with large number of identifiers in Bulk edit on Sprint testing environment:

- not all, but part of the records processed

- .csv file with matched records included not all, but part of the records

## Approach
Add synchronization for matched and processed in spring batch.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
