### PR TITLE
MODBULKOPS-609 - Incorrect Preview of records changed when edit FOLIO & MARC Instances via FOLIO flow

### DIFF
--- a/src/main/java/org/folio/bulkops/service/PreviewService.java
+++ b/src/main/java/org/folio/bulkops/service/PreviewService.java
@@ -181,7 +181,7 @@ public class PreviewService {
             }
           } else {
             yield buildPreviewFromJsonWithChangedOptions(
-                operation, operation.getLinkToCommittedRecordsJsonPreviewFile(), offset, limit);
+                operation, operation.getLinkToCommittedRecordsJsonFile(), offset, limit);
           }
         }
       }


### PR DESCRIPTION
[MODBULKOPS-609](https://folio-org.atlassian.net/browse/MODBULKOPS-609) - Incorrect Preview of records changed when edit FOLIO & MARC Instances via FOLIO flow

## Purpose
When upload FOLIO & MARC Instances in bulk edit and add/edit Instance note via FOLIO flow - Preview of records changed on Confirmation screen includes FOLIO & MARC Instances. MARC Instance should not be included in Preview of records changed, but only included in Errors with reason “Bulk edit of instance notes is not supported for MARC Instances.“

## Approach
* Fixed preview JSON creation logic

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
