### PR TITLE
MODBULKOPS-657: Spring Boot 4.0.6 fixing jackson-core vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.2</version>
+    <version>4.0.6</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODBULKOPS-657


## Purpose
Fix security vulnerabilities in jackson-core.

## Approach
Bump Spring Boot from 4.0.2 to 4.0.6.

This transitively bumps jackson-core
* from 2.20.2 to 2.21.2, and
* from 3.0.4 to 3.1.2.

The jackson-core bumps fix multiple security vulnerabilities:
* https://www.cve.org/CVERecord?id=CVE-2026-29062
* https://github.com/FasterXML/jackson-core/security/advisories/GHSA-h46c-h94j-95f3
* https://security.snyk.io/vuln/SNYK-JAVA-TOOLSJACKSONCORE-15365915

## Learning
Bump dependencies before making a release for a flower version.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - n/a Were any API paths or methods changed, added or removed?
  - n/a Were there any schema changes?
  - n/a Did any of the interface versions change?
  - n/a Were permissions changed, added, or removed?
  - n/a Are there new interface dependencies?
  - n/a There are no breaking changes in this PR.