### PR TITLE
MODBULKOPS-603 - Occasionally Matching preview displays not all uploaded records when upload .csv file with large number of identifiers

### DIFF
--- a/src/main/java/org/folio/bulkops/batch/jobs/processidentifiers/IdentifiersWriteListener.java
+++ b/src/main/java/org/folio/bulkops/batch/jobs/processidentifiers/IdentifiersWriteListener.java
@@ -27,7 +27,7 @@ public class IdentifiersWriteListener<T> implements ItemWriteListener<T> {
 
   @SuppressWarnings("unused")
   @Value("#{stepExecution.jobExecution}")
-  private JobExecution jobExecution;
+  private final JobExecution jobExecution;
 
   @Override
   public void beforeWrite(Chunk<? extends T> list) {
@@ -38,7 +38,7 @@ public class IdentifiersWriteListener<T> implements ItemWriteListener<T> {
   public void afterWrite(Chunk<? extends T> list) {
     int processed;
     int matched;
-    synchronized (this) {
+    synchronized (jobExecution) {
       var context = jobExecution.getExecutionContext();
       processed = list.size();
       matched = list.size();

--- a/src/main/java/org/folio/bulkops/batch/jobs/processidentifiers/IdentifiersWriteListener.java
+++ b/src/main/java/org/folio/bulkops/batch/jobs/processidentifiers/IdentifiersWriteListener.java
@@ -27,7 +27,7 @@ public class IdentifiersWriteListener<T> implements ItemWriteListener<T> {
 
   @SuppressWarnings("unused")
   @Value("#{stepExecution.jobExecution}")
-  private final JobExecution jobExecution;
+  private JobExecution jobExecution;
 
   @Override
   public void beforeWrite(Chunk<? extends T> list) {


### PR DESCRIPTION
[MODBULKOPS-603](https://folio-org.atlassian.net/browse/MODBULKOPS-603) - Occasionally Matching preview displays not all uploaded records when upload .csv file with large number of identifiers

## Purpose
Fix matched records for 100k HRIDs (100 or 200 less).

## Approach
Synchronize on jobExecution.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
