### PR TITLE
MODBULKOPS-658 - MARC Instances - Replace - "Remove all" with "Remove field" and "Remove subfield"

### DIFF
--- a/src/main/java/org/folio/bulkops/exception/BulkOperationsExceptionHandler.java
+++ b/src/main/java/org/folio/bulkops/exception/BulkOperationsExceptionHandler.java
@@ -12,6 +12,11 @@ public class BulkOperationsExceptionHandler {
     return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
   }
 
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<String> handleBadRequestException(final BadRequestException e) {
+    return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+  }
+
   @ExceptionHandler(IllegalOperationStateException.class)
   public ResponseEntity<String> handleIllegalOperationStateException(
       final IllegalOperationStateException e) {

--- a/src/main/java/org/folio/bulkops/processor/marc/MarcInstanceDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/marc/MarcInstanceDataProcessor.java
@@ -9,6 +9,7 @@ import static org.folio.bulkops.domain.dto.UpdateActionType.ADD_TO_EXISTING;
 import static org.folio.bulkops.domain.dto.UpdateActionType.FIND;
 import static org.folio.bulkops.domain.dto.UpdateActionType.REMOVE_ALL;
 import static org.folio.bulkops.domain.dto.UpdateActionType.REMOVE_FIELD;
+import static org.folio.bulkops.domain.dto.UpdateActionType.REMOVE_SUBFIELD;
 import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_FALSE;
 import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_TRUE;
 import static org.folio.bulkops.util.Constants.SPACE_CHAR;
@@ -108,10 +109,12 @@ public class MarcInstanceDataProcessor implements MarcDataProcessor {
       }
     } else if (REMOVE_ALL == actions.get(0).getName()) {
       processRemoveAll(rule, marcRecord);
+    } else if (REMOVE_FIELD == actions.get(0).getName()) {
+      processRemoveField(rule, marcRecord);
+    } else if (REMOVE_SUBFIELD == actions.get(0).getName()) {
+      processRemoveSubfield(rule, marcRecord);
     } else if (ADD_TO_EXISTING.equals(actions.get(0).getName())) {
       processAddToExisting(rule, marcRecord);
-    } else if (REMOVE_FIELD == actions.get(0).getName()) {
-      processFindAndRemoveField(rule, marcRecord);
     } else {
       if (rule.getUpdateOption() == UpdateOptionType.SET_RECORDS_FOR_DELETE) {
         if (SET_TO_TRUE.equals(actions.getFirst().getName())) {
@@ -236,6 +239,32 @@ public class MarcInstanceDataProcessor implements MarcDataProcessor {
                     && dataField.getIndicator2() == ind2
                     && dataField.getSubfields().stream()
                         .anyMatch(subfield -> subfield.getCode() == subfieldCode));
+  }
+
+  private void processRemoveField(BulkOperationMarcRule rule, Record marcRecord) {
+    char ind1 = fetchIndicatorValue(rule.getInd1());
+    char ind2 = fetchIndicatorValue(rule.getInd2());
+    marcRecord
+        .getDataFields()
+        .removeIf(
+            dataField ->
+                rule.getTag().equals(dataField.getTag())
+                    && ind1 == dataField.getIndicator1()
+                    && ind2 == dataField.getIndicator2());
+  }
+
+  private void processRemoveSubfield(BulkOperationMarcRule rule, Record marcRecord) {
+    char subfieldCode = rule.getSubfield().charAt(0);
+    var fieldsToRemove = new java.util.ArrayList<DataField>();
+    findFields(rule, marcRecord)
+        .forEach(
+            df -> {
+              df.getSubfields(subfieldCode).forEach(df::removeSubfield);
+              if (df.getSubfields().isEmpty()) {
+                fieldsToRemove.add(df);
+              }
+            });
+    fieldsToRemove.forEach(marcRecord::removeVariableField);
   }
 
   private void processAddToExisting(BulkOperationMarcRule rule, Record marcRecord)

--- a/src/main/java/org/folio/bulkops/processor/marc/MarcInstanceDataProcessor.java
+++ b/src/main/java/org/folio/bulkops/processor/marc/MarcInstanceDataProcessor.java
@@ -8,6 +8,7 @@ import static org.folio.bulkops.domain.dto.MarcDataType.VALUE;
 import static org.folio.bulkops.domain.dto.UpdateActionType.ADD_TO_EXISTING;
 import static org.folio.bulkops.domain.dto.UpdateActionType.FIND;
 import static org.folio.bulkops.domain.dto.UpdateActionType.REMOVE_ALL;
+import static org.folio.bulkops.domain.dto.UpdateActionType.REMOVE_FIELD;
 import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_FALSE;
 import static org.folio.bulkops.domain.dto.UpdateActionType.SET_TO_TRUE;
 import static org.folio.bulkops.util.Constants.SPACE_CHAR;
@@ -109,6 +110,8 @@ public class MarcInstanceDataProcessor implements MarcDataProcessor {
       processRemoveAll(rule, marcRecord);
     } else if (ADD_TO_EXISTING.equals(actions.get(0).getName())) {
       processAddToExisting(rule, marcRecord);
+    } else if (REMOVE_FIELD == actions.get(0).getName()) {
+      processFindAndRemoveField(rule, marcRecord);
     } else {
       if (rule.getUpdateOption() == UpdateOptionType.SET_RECORDS_FOR_DELETE) {
         if (SET_TO_TRUE.equals(actions.getFirst().getName())) {

--- a/src/main/java/org/folio/bulkops/processor/marc/MarcRulesValidator.java
+++ b/src/main/java/org/folio/bulkops/processor/marc/MarcRulesValidator.java
@@ -3,6 +3,8 @@ package org.folio.bulkops.processor.marc;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.bulkops.domain.dto.BulkOperationMarcRule;
+import org.folio.bulkops.domain.dto.UpdateActionType;
+import org.folio.bulkops.exception.BadRequestException;
 import org.folio.bulkops.exception.RuleValidationException;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +15,7 @@ public class MarcRulesValidator {
   private static final Pattern UNSUPPORTED_TAG_PATTERN = Pattern.compile("00\\d");
   private static final String NOT_SUPPORTED_BULK_EDIT_FIELD_MESSAGE =
       "Bulk edit of %s field is not supported";
+  static final String MISSING_REQUIRED_FIELD_MESSAGE = "Missing required field %s.";
 
   public void validate(BulkOperationMarcRule bulkOperationMarcRule) throws RuleValidationException {
     var tag = bulkOperationMarcRule.getTag();
@@ -20,6 +23,48 @@ public class MarcRulesValidator {
         || !TAG_PATTERN.matcher(tag).matches()
         || UNSUPPORTED_TAG_PATTERN.matcher(tag).matches()) {
       throw new RuleValidationException(String.format(NOT_SUPPORTED_BULK_EDIT_FIELD_MESSAGE, tag));
+    }
+  }
+
+  /**
+   * Validates that all required fields are present for REMOVE_FIELD and REMOVE_SUBFIELD operations.
+   *
+   * <ul>
+   *   <li>REMOVE_FIELD requires: tag, ind1, ind2
+   *   <li>REMOVE_SUBFIELD requires: tag, ind1, ind2, subfield
+   * </ul>
+   *
+   * @throws BadRequestException with message "Missing required field &lt;name&gt;." if a required
+   *     field is absent
+   */
+  public void validateRequiredFields(BulkOperationMarcRule rule) {
+    if (rule.getActions() == null || rule.getActions().isEmpty()) {
+      return;
+    }
+    var firstAction = rule.getActions().get(0).getName();
+    if (UpdateActionType.REMOVE_FIELD.equals(firstAction)) {
+      validateRemoveFieldRequiredFields(rule);
+    } else if (UpdateActionType.REMOVE_SUBFIELD.equals(firstAction)) {
+      validateRemoveSubfieldRequiredFields(rule);
+    }
+  }
+
+  private void validateRemoveFieldRequiredFields(BulkOperationMarcRule rule) {
+    if (StringUtils.isEmpty(rule.getTag())) {
+      throw new BadRequestException(String.format(MISSING_REQUIRED_FIELD_MESSAGE, "tag"));
+    }
+    if (StringUtils.isEmpty(rule.getInd1())) {
+      throw new BadRequestException(String.format(MISSING_REQUIRED_FIELD_MESSAGE, "ind1"));
+    }
+    if (StringUtils.isEmpty(rule.getInd2())) {
+      throw new BadRequestException(String.format(MISSING_REQUIRED_FIELD_MESSAGE, "ind2"));
+    }
+  }
+
+  private void validateRemoveSubfieldRequiredFields(BulkOperationMarcRule rule) {
+    validateRemoveFieldRequiredFields(rule);
+    if (StringUtils.isEmpty(rule.getSubfield())) {
+      throw new BadRequestException(String.format(MISSING_REQUIRED_FIELD_MESSAGE, "subfield"));
     }
   }
 }

--- a/src/main/java/org/folio/bulkops/service/RuleService.java
+++ b/src/main/java/org/folio/bulkops/service/RuleService.java
@@ -14,6 +14,7 @@ import org.folio.bulkops.domain.dto.RuleDetails;
 import org.folio.bulkops.domain.dto.UpdateOptionType;
 import org.folio.bulkops.domain.entity.BulkOperation;
 import org.folio.bulkops.mapper.MarcRulesMapper;
+import org.folio.bulkops.processor.marc.MarcRulesValidator;
 import org.folio.bulkops.repository.BulkOperationMarcRuleRepository;
 import org.folio.bulkops.repository.BulkOperationRuleDetailsRepository;
 import org.folio.bulkops.repository.BulkOperationRuleRepository;
@@ -29,6 +30,7 @@ public class RuleService {
   private final BulkOperationMarcRuleRepository marcRuleRepository;
   private final MarcRulesMapper marcRulesMapper;
   private final ApplicationContext applicationContext;
+  private final MarcRulesValidator marcRulesValidator;
 
   @Transactional
   public BulkOperationRuleCollection saveRules(
@@ -131,7 +133,11 @@ public class RuleService {
 
     ruleCollection
         .getBulkOperationMarcRules()
-        .forEach(marcRule -> marcRuleRepository.save(marcRulesMapper.mapToEntity(marcRule)));
+        .forEach(
+            marcRule -> {
+              marcRulesValidator.validateRequiredFields(marcRule);
+              marcRuleRepository.save(marcRulesMapper.mapToEntity(marcRule));
+            });
 
     return ruleCollection;
   }

--- a/src/main/resources/swagger.api/schemas/marc_rule_details.json
+++ b/src/main/resources/swagger.api/schemas/marc_rule_details.json
@@ -51,7 +51,6 @@
       "tag",
       "ind1",
       "ind2",
-      "subfield",
       "actions"
     ],
     "additionalProperties": false

--- a/src/test/java/org/folio/bulkops/processor/marc/MarcInstanceDataProcessorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/marc/MarcInstanceDataProcessorTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.bulkops.domain.dto.UpdateActionType.ADDITIONAL_SUBFIELD;
 import static org.folio.bulkops.domain.dto.UpdateActionType.ADD_TO_EXISTING;
 import static org.folio.bulkops.domain.dto.UpdateActionType.FIND;
+import static org.folio.bulkops.domain.dto.UpdateActionType.REMOVE_FIELD;
+import static org.folio.bulkops.domain.dto.UpdateActionType.REMOVE_SUBFIELD;
 import static org.folio.bulkops.util.Constants.DATE_TIME_CONTROL_FIELD;
 import static org.folio.bulkops.util.Constants.HYPHEN;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1134,5 +1136,113 @@ class MarcInstanceDataProcessorTest extends BaseTest {
     // Field should remain with updated value
     assertThat(dataFields).hasSize(1);
     assertThat(dataFields.get(0)).hasToString("500 1 $anew value");
+  }
+
+  @Test
+  @SneakyThrows
+  void shouldRemoveFieldByTagAndIndicators() {
+    var marcRecord = new RecordImpl();
+    marcRecord.setLeader(new LeaderImpl("04295nam a22004573a 4500"));
+
+    var controlField = new ControlFieldImpl(DATE_TIME_CONTROL_FIELD, "20240101100202.4");
+    marcRecord.addVariableField(controlField);
+
+    // Fields to be removed (tag=500, ind1=1, ind2=1)
+    var dataField = new DataFieldImpl("500", '1', '1');
+    dataField.addSubfield(new SubfieldImpl('a', "text a"));
+    marcRecord.addVariableField(dataField);
+    dataField = new DataFieldImpl("500", '1', '1');
+    dataField.addSubfield(new SubfieldImpl('b', "text b"));
+    marcRecord.addVariableField(dataField);
+
+    // Field NOT removed (different indicator)
+    dataField = new DataFieldImpl("500", '1', '2');
+    dataField.addSubfield(new SubfieldImpl('a', "keep me"));
+    marcRecord.addVariableField(dataField);
+
+    // Field NOT removed (different tag)
+    dataField = new DataFieldImpl("510", '1', '1');
+    dataField.addSubfield(new SubfieldImpl('a', "keep me too"));
+    marcRecord.addVariableField(dataField);
+
+    var pattern = "yyyy/MM/dd HH:mm:ss.SSS";
+    var simpleDateFormat = new SimpleDateFormat(pattern);
+    var date = simpleDateFormat.parse("2024/01/01 11:12:12.454");
+    var bulkOperationId = UUID.randomUUID();
+    var operation =
+        BulkOperation.builder().id(bulkOperationId).identifierType(IdentifierType.ID).build();
+
+    var removeFieldRule =
+        new BulkOperationMarcRule()
+            .bulkOperationId(bulkOperationId)
+            .tag("500")
+            .ind1("1")
+            .ind2("1")
+            .actions(List.of(new MarcAction().name(REMOVE_FIELD)));
+    var rules =
+        new BulkOperationMarcRuleCollection()
+            .bulkOperationMarcRules(Collections.singletonList(removeFieldRule))
+            .totalRecords(1);
+
+    processor.update(operation, marcRecord, rules, date);
+
+    var dataFields = marcRecord.getDataFields();
+    assertThat(dataFields).hasSize(2);
+    assertThat(dataFields.get(0)).hasToString("500 12$akeep me");
+    assertThat(dataFields.get(1)).hasToString("510 11$akeep me too");
+  }
+
+  @Test
+  @SneakyThrows
+  void shouldRemoveSubfieldByTagIndicatorsAndSubfieldCode() {
+    var marcRecord = new RecordImpl();
+    marcRecord.setLeader(new LeaderImpl("04295nam a22004573a 4500"));
+
+    var controlField = new ControlFieldImpl(DATE_TIME_CONTROL_FIELD, "20240101100202.4");
+    marcRecord.addVariableField(controlField);
+
+    // Field with two subfields - only subfield 'a' should be removed
+    var dataField = new DataFieldImpl("500", '1', '1');
+    dataField.addSubfield(new SubfieldImpl('a', "remove me"));
+    dataField.addSubfield(new SubfieldImpl('b', "keep me"));
+    marcRecord.addVariableField(dataField);
+
+    // Field with only one subfield 'a' - entire field should be removed
+    dataField = new DataFieldImpl("500", '1', '1');
+    dataField.addSubfield(new SubfieldImpl('a', "only subfield"));
+    marcRecord.addVariableField(dataField);
+
+    // Field with different tag - not affected
+    dataField = new DataFieldImpl("510", '1', '1');
+    dataField.addSubfield(new SubfieldImpl('a', "different tag"));
+    marcRecord.addVariableField(dataField);
+
+    var pattern = "yyyy/MM/dd HH:mm:ss.SSS";
+    var simpleDateFormat = new SimpleDateFormat(pattern);
+    var date = simpleDateFormat.parse("2024/01/01 11:12:12.454");
+    var bulkOperationId = UUID.randomUUID();
+    var operation =
+        BulkOperation.builder().id(bulkOperationId).identifierType(IdentifierType.ID).build();
+
+    var removeSubfieldRule =
+        new BulkOperationMarcRule()
+            .bulkOperationId(bulkOperationId)
+            .tag("500")
+            .ind1("1")
+            .ind2("1")
+            .subfield("a")
+            .actions(List.of(new MarcAction().name(REMOVE_SUBFIELD)));
+    var rules =
+        new BulkOperationMarcRuleCollection()
+            .bulkOperationMarcRules(Collections.singletonList(removeSubfieldRule))
+            .totalRecords(1);
+
+    processor.update(operation, marcRecord, rules, date);
+
+    var dataFields = marcRecord.getDataFields();
+    // The field with only subfield 'a' is removed entirely; field with 'b' remains; 510 unchanged
+    assertThat(dataFields).hasSize(2);
+    assertThat(dataFields.get(0)).hasToString("500 11$bkeep me");
+    assertThat(dataFields.get(1)).hasToString("510 11$adifferent tag");
   }
 }

--- a/src/test/java/org/folio/bulkops/processor/marc/MarcRulesValidatorTest.java
+++ b/src/test/java/org/folio/bulkops/processor/marc/MarcRulesValidatorTest.java
@@ -1,17 +1,23 @@
 package org.folio.bulkops.processor.marc;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
 import org.folio.bulkops.domain.dto.BulkOperationMarcRule;
+import org.folio.bulkops.domain.dto.MarcAction;
+import org.folio.bulkops.domain.dto.UpdateActionType;
+import org.folio.bulkops.exception.BadRequestException;
 import org.folio.bulkops.exception.RuleValidationException;
 import org.junit.jupiter.api.Test;
 
 class MarcRulesValidatorTest {
 
+  private final MarcRulesValidator validator = new MarcRulesValidator();
+
   @Test
   void testValidate() {
-    var validator = new MarcRulesValidator();
     var bulkOperationMarcRule = new BulkOperationMarcRule();
     bulkOperationMarcRule.setTag(null);
     assertThrows(RuleValidationException.class, () -> validator.validate(bulkOperationMarcRule));
@@ -24,5 +30,115 @@ class MarcRulesValidatorTest {
     assertDoesNotThrow(() -> validator.validate(bulkOperationMarcRule));
     bulkOperationMarcRule.setTag("909");
     assertDoesNotThrow(() -> validator.validate(bulkOperationMarcRule));
+  }
+
+  // --- REMOVE_FIELD validation ---
+
+  @Test
+  void validateRequiredFields_removeField_missingTag_throwsBadRequest() {
+    var rule =
+        new BulkOperationMarcRule()
+            .ind1("1")
+            .ind2("1")
+            .actions(List.of(new MarcAction().name(UpdateActionType.REMOVE_FIELD)));
+    var ex = assertThrows(BadRequestException.class, () -> validator.validateRequiredFields(rule));
+    assertEquals(
+        String.format(MarcRulesValidator.MISSING_REQUIRED_FIELD_MESSAGE, "tag"), ex.getMessage());
+  }
+
+  @Test
+  void validateRequiredFields_removeField_missingInd1_throwsBadRequest() {
+    var rule =
+        new BulkOperationMarcRule()
+            .tag("500")
+            .ind2("1")
+            .actions(List.of(new MarcAction().name(UpdateActionType.REMOVE_FIELD)));
+    var ex = assertThrows(BadRequestException.class, () -> validator.validateRequiredFields(rule));
+    assertEquals(
+        String.format(MarcRulesValidator.MISSING_REQUIRED_FIELD_MESSAGE, "ind1"), ex.getMessage());
+  }
+
+  @Test
+  void validateRequiredFields_removeField_missingInd2_throwsBadRequest() {
+    var rule =
+        new BulkOperationMarcRule()
+            .tag("500")
+            .ind1("1")
+            .actions(List.of(new MarcAction().name(UpdateActionType.REMOVE_FIELD)));
+    var ex = assertThrows(BadRequestException.class, () -> validator.validateRequiredFields(rule));
+    assertEquals(
+        String.format(MarcRulesValidator.MISSING_REQUIRED_FIELD_MESSAGE, "ind2"), ex.getMessage());
+  }
+
+  @Test
+  void validateRequiredFields_removeField_subfieldNotRequired_passes() {
+    var rule =
+        new BulkOperationMarcRule()
+            .tag("500")
+            .ind1("1")
+            .ind2("1")
+            .actions(List.of(new MarcAction().name(UpdateActionType.REMOVE_FIELD)));
+    assertDoesNotThrow(() -> validator.validateRequiredFields(rule));
+  }
+
+  // --- REMOVE_SUBFIELD validation ---
+
+  @Test
+  void validateRequiredFields_removeSubfield_missingSubfield_throwsBadRequest() {
+    var rule =
+        new BulkOperationMarcRule()
+            .tag("500")
+            .ind1("1")
+            .ind2("1")
+            .actions(List.of(new MarcAction().name(UpdateActionType.REMOVE_SUBFIELD)));
+    var ex = assertThrows(BadRequestException.class, () -> validator.validateRequiredFields(rule));
+    assertEquals(
+        String.format(MarcRulesValidator.MISSING_REQUIRED_FIELD_MESSAGE, "subfield"),
+        ex.getMessage());
+  }
+
+  @Test
+  void validateRequiredFields_removeSubfield_allPresent_passes() {
+    var rule =
+        new BulkOperationMarcRule()
+            .tag("500")
+            .ind1("1")
+            .ind2("1")
+            .subfield("a")
+            .actions(List.of(new MarcAction().name(UpdateActionType.REMOVE_SUBFIELD)));
+    assertDoesNotThrow(() -> validator.validateRequiredFields(rule));
+  }
+
+  @Test
+  void validateRequiredFields_removeSubfield_missingInd1_throwsBadRequest() {
+    var rule =
+        new BulkOperationMarcRule()
+            .tag("500")
+            .ind2("1")
+            .subfield("a")
+            .actions(List.of(new MarcAction().name(UpdateActionType.REMOVE_SUBFIELD)));
+    var ex = assertThrows(BadRequestException.class, () -> validator.validateRequiredFields(rule));
+    assertEquals(
+        String.format(MarcRulesValidator.MISSING_REQUIRED_FIELD_MESSAGE, "ind1"), ex.getMessage());
+  }
+
+  // --- Other actions are not validated ---
+
+  @Test
+  void validateRequiredFields_otherAction_noValidation() {
+    // Other actions (e.g. FIND, ADD_TO_EXISTING) do not trigger required-field validation
+    var rule =
+        new BulkOperationMarcRule()
+            .tag("500")
+            .ind1("1")
+            .ind2("1")
+            .actions(List.of(new MarcAction().name(UpdateActionType.ADD_TO_EXISTING)));
+    assertDoesNotThrow(() -> validator.validateRequiredFields(rule));
+  }
+
+  @Test
+  void validateRequiredFields_emptyActions_noValidation() {
+    var rule = new BulkOperationMarcRule().tag("500").ind1("1").ind2("1");
+    assertDoesNotThrow(() -> validator.validateRequiredFields(rule));
   }
 }


### PR DESCRIPTION
[MODBULKOPS-658 ](https://folio-org.atlassian.net/browse/MODBULKOPS-658) - MARC Instances - Replace - "Remove all" with "Remove field" and "Remove subfield"

## Purpose
The existing “Remove all” behavior in Bulk Edit for MARC instances is unintuitive as users must enter a subfield even when they want to remove an entire field. 

## Approach

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
